### PR TITLE
feat(core): view-level associations (closes #4)

### DIFF
--- a/.changeset/view-level-associations.md
+++ b/.changeset/view-level-associations.md
@@ -1,0 +1,11 @@
+---
+"@pgbo/core": minor
+---
+
+Add view-level associations (issue #4).
+
+`ViewDef` now supports `.associations({ name: { foreignKey, target } })`. BOs inherit view-declared associations automatically — no need to redeclare them on every BO that shares a view. BO-level `associations` still work and take precedence on key collision.
+
+`viewMeta()` surfaces associations in its output (new `associations: AssociationMeta[]` field), so metadata endpoints and low-level consumers can resolve relations without BO context.
+
+Compositions stay BO-only (they carry write-time cascade semantics).

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -278,6 +278,38 @@ const warehouseValueHelp = valueHelpView('warehouse_vh')
   .display('name')
 ```
 
+### Associations
+
+Declare read-time navigation relations on the view. BOs built on this view inherit them automatically — no need to redeclare in `defineBO()`.
+
+```typescript
+const pageView = view('page_view')
+  .from(pageTable)
+  .associations({
+    area: { foreignKey: 'areaId', target: areaView },
+    author: { foreignKey: 'authorId', target: userView },
+  })
+  .columns({ /* ... */ })
+```
+
+The `target` is optional but recommended — `viewMeta().associations` surfaces it so metadata endpoints and enrichment utilities can resolve relations without BO context.
+
+BO-level `associations` still work and take precedence on key collision:
+
+```typescript
+const pageBO = defineBO(pageView, {
+  paramField: 'id',
+  // Inherits { area, author } from the view.
+  // Can override or add more:
+  associations: {
+    area: { foreignKey: 'customAreaId' },  // overrides view's
+    extra: { foreignKey: 'extraId' },       // adds a new one
+  },
+})
+```
+
+Compositions (write-time cascade semantics) stay BO-only — they aren't inherited from the view.
+
 ### Auth Restrictions
 
 Views carry declarative auth annotations. pgbo enforces them via a pluggable handler before query execution:

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -40,13 +40,17 @@ export function defineBO<
     }
   }
 
+  // Inherit associations from the view. BO-level associations override by key.
+  const viewAssocs = 'viewAssociations' in root ? root.viewAssociations ?? {} : {}
+  const associations = { ...viewAssocs, ...(config.associations ?? {}) }
+
   const bo: BusinessObjectDef = {
     name: config.name ?? snakeToCamel(root.name),
     root,
     paramField: config.paramField ?? 'id',
     actions: config.actions ?? {},
     compositions,
-    associations: config.associations ?? {},
+    associations,
     valueHelps: config.valueHelps ?? {},
     isReadOnly: !config.actions || Object.keys(config.actions).length === 0,
     routePrefix: config.routePrefix,

--- a/packages/pgbo/src/bo/types.ts
+++ b/packages/pgbo/src/bo/types.ts
@@ -1,6 +1,6 @@
 // Business Object type definitions — Phase 7 (Step 17)
 
-import type { ViewDef, ValueHelpViewDef, TableDef, AnyColumnBuilder, FieldKind } from '../schema/definitions.js'
+import type { ViewDef, ValueHelpViewDef, TableDef, AnyColumnBuilder, FieldKind, AssociationDef } from '../schema/definitions.js'
 import type { InferRow, InferInsert, InferUpdate } from '../schema/infer.js'
 
 export type ActionContext = Record<string, unknown>;
@@ -35,7 +35,7 @@ export interface BusinessObjectDef {
   readonly paramField: string
   readonly actions: Readonly<Record<string, ActionDef>>
   readonly compositions: Readonly<Record<string, CompositionDef>>
-  readonly associations: Readonly<Record<string, { foreignKey: string }>>
+  readonly associations: Readonly<Record<string, AssociationDef>>
   readonly valueHelps: Readonly<Record<string, ValueHelpViewDef>>
   readonly isReadOnly: boolean
   readonly routePrefix?: string
@@ -51,7 +51,7 @@ export interface BOConfig<C extends Record<string, AnyColumnBuilder> = Record<st
   paramField?: string & keyof C
   actions?: Record<string, ActionDef>
   compositions?: Record<string, CompositionDef | ViewDef | TableDef>
-  associations?: Record<string, { foreignKey: string }>
+  associations?: Record<string, AssociationDef>
   valueHelps?: Record<string, ValueHelpViewDef>
   routePrefix?: string
   orderBy?: string

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -132,7 +132,14 @@ export function viewMeta(source: ViewDef | TableDef): ViewMeta {
     }
   }
 
-  return { name: source.name, fields }
+  const viewAssocs = isViewDef(source) ? source.viewAssociations ?? {} : {}
+  const associations = Object.entries(viewAssocs).map(([name, assoc]) => ({
+    name,
+    foreignKey: assoc.foreignKey,
+    target: assoc.target?.name,
+  }))
+
+  return { name: source.name, fields, associations }
 }
 
 // --- R2: boMeta ---
@@ -204,9 +211,17 @@ export function boMeta(
     fields: viewMeta(vh.view).fields,
   }))
 
+  // Merge view associations with BO-level associations (BO wins on key collision)
+  const associations = Object.entries(bo.associations).map(([name, assoc]) => ({
+    name,
+    foreignKey: assoc.foreignKey,
+    target: assoc.target?.name,
+  }))
+
   return {
     name: base.name,
     fields,
+    associations,
     paramField: bo.paramField,
     readOnly: bo.isReadOnly,
     compositions,

--- a/packages/pgbo/src/metadata/types.ts
+++ b/packages/pgbo/src/metadata/types.ts
@@ -24,9 +24,16 @@ export interface FieldMeta {
   readonly quick: boolean
 }
 
+export interface AssociationMeta {
+  readonly name: string
+  readonly foreignKey: string
+  readonly target?: string
+}
+
 export interface ViewMeta {
   readonly name: string
   readonly fields: readonly FieldMeta[]
+  readonly associations: readonly AssociationMeta[]
 }
 
 export interface CompositionMeta {

--- a/packages/pgbo/src/schema/definitions.ts
+++ b/packages/pgbo/src/schema/definitions.ts
@@ -244,6 +244,17 @@ type Simplify<T> = { [K in keyof T]: T[K] } & {}
 type InferColumnsMap<M extends Record<string, any>, SourceCols extends Record<string, AnyColumnBuilder> = Record<string, AnyColumnBuilder>> =
   Simplify<{ [K in keyof M]: InferColEntry<M[K], SourceCols> }>
 
+// --- Association ---
+
+/**
+ * Read-time navigation relation from this view/BO to another entity.
+ * `target` is optional and identifies the referenced view/table for metadata + enrichment.
+ */
+export interface AssociationDef {
+  readonly foreignKey: string
+  readonly target?: ViewDef | TableDef
+}
+
 // --- View ---
 
 export interface ViewDef<
@@ -257,6 +268,7 @@ export interface ViewDef<
   readonly whereClause?: string
   readonly restrictions?: readonly Restriction[]
   readonly isNoAuth?: boolean
+  readonly viewAssociations?: Readonly<Record<string, AssociationDef>>
   /** Phantom type carrying the inferred row shape */
   readonly _rowType?: TRow
   from<C extends Record<string, AnyColumnBuilder>>(table: TableDef<C>): ViewDef<TRow, C>
@@ -268,6 +280,8 @@ export interface ViewDef<
   restrict(r: Restriction): ViewDef<TRow, SC>
   /** Mark this view as requiring no auth (e.g. value helps) */
   noAuth(): ViewDef<TRow, SC>
+  /** Declare read-time navigation relations. BOs built on this view inherit them. */
+  associations(assocs: Record<string, AssociationDef>): ViewDef<TRow, SC>
   /** Brand the view with an explicit row type (escape hatch) */
   as<T extends Record<string, unknown>>(): ViewDef<T>
   toSQL(): string

--- a/packages/pgbo/src/schema/view.ts
+++ b/packages/pgbo/src/schema/view.ts
@@ -1,6 +1,6 @@
 // View builder — Phase 3 (Step 11) + i18n + JOIN support + typed columns
 
-import type { TableDef, ViewDef, ValueHelpViewDef, ColumnRef, JoinDef, SubqueryCountRef, Restriction } from './definitions.js'
+import type { TableDef, ViewDef, ValueHelpViewDef, ColumnRef, JoinDef, SubqueryCountRef, Restriction, AssociationDef } from './definitions.js'
 import type { TranslatedRef } from './i18n.js'
 import { isTranslatedRef } from './i18n.js'
 import { isSubqueryCountRef } from './subquery.js'
@@ -21,6 +21,7 @@ function createViewDef(
   whereClause?: string,
   restrictions?: readonly Restriction[],
   isNoAuth?: boolean,
+  viewAssociations?: Readonly<Record<string, AssociationDef>>,
 ): ViewDef<any, any> {
   const self: ViewDef = {
     name,
@@ -30,35 +31,40 @@ function createViewDef(
     whereClause,
     restrictions,
     isNoAuth,
+    viewAssociations,
 
     from(table: TableDef) {
-      return createViewDef(name, table, joins, selectedColumns, whereClause, restrictions, isNoAuth)
+      return createViewDef(name, table, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations)
     },
 
     join(table: TableDef, on: Record<string, string>) {
       const newJoin: JoinDef = { table, on, type: 'JOIN' }
-      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth)
+      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations)
     },
 
     leftJoin(table: TableDef, on: Record<string, string>) {
       const newJoin: JoinDef = { table, on, type: 'LEFT JOIN' }
-      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth)
+      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations)
     },
 
     columns(cols: Record<string, ColumnEntry>) {
-      return createViewDef(name, source, joins, cols, whereClause, restrictions, isNoAuth)
+      return createViewDef(name, source, joins, cols, whereClause, restrictions, isNoAuth, viewAssociations)
     },
 
     where(condition: string) {
-      return createViewDef(name, source, joins, selectedColumns, condition, restrictions, isNoAuth)
+      return createViewDef(name, source, joins, selectedColumns, condition, restrictions, isNoAuth, viewAssociations)
     },
 
     restrict(r: Restriction) {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, [...(restrictions ?? []), r], isNoAuth)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, [...(restrictions ?? []), r], isNoAuth, viewAssociations)
     },
 
     noAuth() {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, true)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, true, viewAssociations)
+    },
+
+    associations(assocs: Record<string, AssociationDef>) {
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, { ...viewAssociations, ...assocs })
     },
 
     as<T extends Record<string, unknown>>() {

--- a/packages/pgbo/tests/schema/view-associations.test.ts
+++ b/packages/pgbo/tests/schema/view-associations.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { view } from '../../src/schema/view.js'
+import { text, integer } from '../../src/schema/types.js'
+import { defineBO } from '../../src/bo/index.js'
+import { viewMeta, boMeta } from '../../src/metadata/index.js'
+
+const areaTable = table('area', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+  },
+  primaryKey: ['id'],
+})
+
+const areaView = view('area_view').from(areaTable)
+
+const pageTable = table('page', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+    areaId: integer().notNull(),
+  },
+  primaryKey: ['id'],
+})
+
+describe('View-level associations (issue #4)', () => {
+  it('.associations() attaches metadata to the view', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+
+    expect(pageView.viewAssociations).toBeDefined()
+    expect(pageView.viewAssociations?.area?.foreignKey).toBe('areaId')
+    expect(pageView.viewAssociations?.area?.target?.name).toBe('area_view')
+  })
+
+  it('viewMeta() surfaces associations', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+
+    const meta = viewMeta(pageView)
+    expect(meta.associations).toHaveLength(1)
+    expect(meta.associations[0]).toEqual({
+      name: 'area',
+      foreignKey: 'areaId',
+      target: 'area_view',
+    })
+  })
+
+  it('viewMeta() returns empty associations for views without them', () => {
+    const plainView = view('plain_view').from(pageTable)
+    expect(viewMeta(plainView).associations).toEqual([])
+  })
+
+  it('BO inherits associations from the view', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+
+    const pageBO = defineBO(pageView, { paramField: 'id' })
+
+    expect(pageBO.associations.area).toBeDefined()
+    expect(pageBO.associations.area?.foreignKey).toBe('areaId')
+    expect(pageBO.associations.area?.target?.name).toBe('area_view')
+  })
+
+  it('BO-level associations override view associations on key collision', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+
+    const pageBO = defineBO(pageView, {
+      paramField: 'id',
+      associations: {
+        area: { foreignKey: 'customAreaId' },  // override
+      },
+    })
+
+    expect(pageBO.associations.area?.foreignKey).toBe('customAreaId')
+  })
+
+  it('BO associations merge with view associations (different keys)', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+
+    const pageBO = defineBO(pageView, {
+      paramField: 'id',
+      associations: {
+        extra: { foreignKey: 'extraId' },
+      },
+    })
+
+    expect(Object.keys(pageBO.associations).sort()).toEqual(['area', 'extra'])
+  })
+
+  it('boMeta() exposes merged associations', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+
+    const pageBO = defineBO(pageView, { paramField: 'id' })
+    const meta = boMeta(pageBO)
+
+    expect(meta.associations).toHaveLength(1)
+    expect(meta.associations[0]).toEqual({
+      name: 'area',
+      foreignKey: 'areaId',
+      target: 'area_view',
+    })
+  })
+
+  it('associations persist through .where() / .columns() chaining', () => {
+    const pageView = view('page_view').from(pageTable)
+      .associations({
+        area: { foreignKey: 'areaId', target: areaView },
+      })
+      .where("id > 0")
+
+    expect(pageView.viewAssociations?.area?.foreignKey).toBe('areaId')
+  })
+})


### PR DESCRIPTION
## Summary

- `ViewDef.associations({ name: { foreignKey, target } })` — views now carry read-time navigation metadata
- BOs inherit view-level associations automatically; BO-level associations override on key collision
- `viewMeta()` / `boMeta()` expose associations so metadata endpoints and enrichment can resolve relations without BO context
- Compositions stay BO-only (they carry write-time cascade semantics)

Closes #4.

## Test plan

- [x] Unit tests in \`tests/schema/view-associations.test.ts\` (8 cases)
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 307 total tests pass
- [x] Changeset added (\`@pgbo/core\` minor, \`@pgbo/fastify\` patch via internal dep bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)