### PR TITLE
feat(fastify): auto-expose custom actions + file responses (closes #5, #7)

### DIFF
--- a/.changeset/custom-actions-and-file-responses.md
+++ b/.changeset/custom-actions-and-file-responses.md
@@ -1,0 +1,15 @@
+---
+"@pgbo/fastify": minor
+---
+
+Auto-expose BO custom actions as HTTP routes, with support for binary file responses (closes #5, #7).
+
+Every non-standard action on a BO (anything besides `create` / `update` / `delete`) is now auto-registered as `POST /bo/{boName}/{actionName}`. The request body is passed as the action's `data` argument. Standard CRUD actions keep their existing REST routes — no duplication.
+
+Return-value handling:
+
+- Any value → JSON body, 200
+- `undefined` or `null` → 204 no body
+- New `FileResponse` shape (`{ data: Buffer | Uint8Array, contentType, filename?, inline? }`) → binary body with `Content-Type` and `Content-Disposition` headers
+
+This eliminates the need for hand-written Fastify wrapper routes around `bo.execute(...)` and enables PDF / XLSX / CSV generation from BO actions without glue code.

--- a/packages/pgbo-fastify/README.md
+++ b/packages/pgbo-fastify/README.md
@@ -41,7 +41,40 @@ await app.listen({ port: 3000 })
 - **GET** `/bo/{name}` — metadata with `labelKey` fallback
 - **GET** `/bo/{name}/valueHelp/{vhName}` — dropdown data sources
 - **POST / PUT / DELETE** — CRUD with action-based gating, afterWrite hooks, and global-record write protection
+- **POST** `/bo/{name}/{actionName}` — auto-registered for every custom BO action
+- **File / binary responses** — return a `FileResponse` from an action handler to send PDF/XLSX/CSV/etc. with proper `Content-Type` and `Content-Disposition`
 - **`registerViewRoute`** — read-only paginated view endpoint
+
+## Custom actions and file responses
+
+Every non-standard action on a BO is auto-exposed as `POST /bo/{boName}/{actionName}`:
+
+```typescript
+import type { FileResponse } from '@pgbo/fastify'
+
+export const documentBO = defineBO(documentTable, {
+  actions: {
+    create: {}, update: {}, delete: {},
+    reverse: {
+      handler: async (ctx, data) => reverseDocument(data.id),
+    },
+    pdf: {
+      handler: async (ctx, data): Promise<FileResponse> => ({
+        data: await renderPdf(data.id),
+        contentType: 'application/pdf',
+        filename: `${data.documentNumber}.pdf`,
+        inline: true,
+      }),
+    },
+  },
+})
+```
+
+- Custom actions that return a value → JSON body, status 200
+- Custom actions that return `undefined` / `null` → status 204 (no body)
+- Custom actions that return `FileResponse` → binary body with `Content-Type` + `Content-Disposition` headers
+
+Standard `create` / `update` / `delete` keep their existing REST routes and are NOT also exposed under `/{actionName}` — no duplication.
 
 See the [full documentation](https://github.com/tim-riep/pgbo) for details.
 

--- a/packages/pgbo-fastify/src/index.ts
+++ b/packages/pgbo-fastify/src/index.ts
@@ -1,4 +1,4 @@
 export { registerBoRoutes, registerViewRoute } from './routes.js'
 export { paginateView, buildTenantWhere } from './helpers.js'
-export type { BoRouteConfig, ViewRouteConfig, RouteContext } from './types.js'
+export type { BoRouteConfig, ViewRouteConfig, RouteContext, FileResponse } from './types.js'
 export type { PaginateOptions } from './helpers.js'

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -6,13 +6,44 @@ import type { ViewDef } from '@pgbo/core/schema'
 import { parseListParams } from '@pgbo/core/query'
 import { boMeta, viewMeta, type BOMeta, type FieldMeta } from '@pgbo/core/metadata'
 import { enrichCompositions } from '@pgbo/core/bo'
-import type { BoRouteConfig, ViewRouteConfig } from './types.js'
+import type { BoRouteConfig, ViewRouteConfig, FileResponse } from './types.js'
 import { paginateView, buildTenantWhere } from './helpers.js'
 
 interface TypedBoMethods {
   create: (db: Database, ctx: unknown, data: unknown) => Promise<unknown>
   update: (db: Database, ctx: unknown, data: unknown) => Promise<unknown>
   delete: (db: Database, ctx: unknown, data: unknown) => Promise<unknown>
+  execute: (db: Database, actionName: string, ctx: unknown, data: unknown) => Promise<unknown>
+}
+
+const STANDARD_ACTIONS = new Set(['create', 'update', 'delete'])
+
+function isFileResponse(value: unknown): value is FileResponse {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  const data = v.data
+  const isBinary = (typeof Buffer !== 'undefined' && Buffer.isBuffer(data)) || data instanceof Uint8Array
+  return isBinary && typeof v.contentType === 'string'
+}
+
+async function sendActionResult(reply: FastifyReply, result: unknown): Promise<void> {
+  if (result === undefined || result === null) {
+    await reply.code(204).send()
+    return
+  }
+  if (isFileResponse(result)) {
+    reply.header('content-type', result.contentType)
+    reply.header('content-length', String(result.data.byteLength))
+    if (result.filename) {
+      const disposition = result.inline ? 'inline' : 'attachment'
+      // Escape quotes in filename per RFC 6266
+      const safe = result.filename.replace(/"/g, '\\"')
+      reply.header('content-disposition', `${disposition}; filename="${safe}"`)
+    }
+    await reply.send(result.data)
+    return
+  }
+  await reply.send(result)
 }
 
 function resolveView(config: BoRouteConfig): ViewDef {
@@ -229,6 +260,19 @@ export function registerBoRoutes(app: FastifyInstance, db: Database, config: BoR
       const result = await boMethods.delete(db, ctx, { [paramField]: paramValue })
       if (config.afterWrite) await config.afterWrite(ctx, 'delete')
       return result
+    })
+  }
+
+  // Custom actions — any action that isn't create/update/delete gets exposed as
+  // POST /bo/{name}/{actionName}. Handler return values are JSON-serialized, or
+  // sent as binary when the handler returns a FileResponse (see types.ts).
+  for (const actionName of Object.keys(bo.actions)) {
+    if (STANDARD_ACTIONS.has(actionName)) continue
+    app.post(`/bo/${bo.name}/${actionName}`, async (req: FastifyRequest, reply: FastifyReply) => {
+      const ctx = await config.extractContext(req)
+      const data = (req.body as Record<string, unknown> | undefined) ?? {}
+      const result = await boMethods.execute(db, actionName, ctx, data)
+      await sendActionResult(reply, result)
     })
   }
 }

--- a/packages/pgbo-fastify/src/types.ts
+++ b/packages/pgbo-fastify/src/types.ts
@@ -32,6 +32,20 @@ export interface BoRouteConfig {
   readonly valueHelps?: Readonly<Record<string, ViewDef | ValueHelpViewDef>>
 }
 
+/**
+ * Return this shape from a custom BO action handler to send a binary response
+ * (PDF, XLSX, CSV, etc.) instead of JSON.
+ */
+export interface FileResponse {
+  readonly data: Buffer | Uint8Array
+  /** MIME type, e.g. 'application/pdf' */
+  readonly contentType: string
+  /** Optional filename — triggers Content-Disposition header */
+  readonly filename?: string
+  /** `inline` (default false) serves the file for in-browser viewing; `attachment` forces download */
+  readonly inline?: boolean
+}
+
 export interface ViewRouteConfig {
   /** The view to expose */
   readonly view: ViewDef

--- a/packages/pgbo-fastify/tests/custom-actions.test.ts
+++ b/packages/pgbo-fastify/tests/custom-actions.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify from 'fastify'
+import { table, view, text, integer } from '@pgbo/core/schema'
+import { defineBO } from '@pgbo/core/bo'
+import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
+import { registerBoRoutes, type FileResponse } from '../src/index.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const roleTable = table('role', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+  },
+  primaryKey: ['id'],
+})
+
+const roleView = view('role_view').from(roleTable)
+
+describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
+  let testDb: TestDatabase
+
+  const roleBO = defineBO(roleTable, {
+    paramField: 'id',
+    routePrefix: '/api/roles',
+    actions: {
+      // Standard
+      create: {},
+      update: {},
+      delete: {},
+      // Custom — returns JSON
+      availableFragments: {
+        handler: (ctx, data) => [
+          { slug: 'MANAGE_STOCK', context: data, user: (ctx as { userId?: string }).userId },
+          { slug: 'MANAGE_USERS' },
+        ],
+      },
+      // Custom — returns a value that echoes the input
+      objectRefValues: {
+        handler: (_ctx, data) => ({ echoed: data }),
+      },
+      // Custom — returns a FileResponse (PDF)
+      pdf: {
+        handler: () => {
+          const buffer = Buffer.from('%PDF-1.4 fake pdf content')
+          return {
+            data: buffer,
+            contentType: 'application/pdf',
+            filename: 'report.pdf',
+            inline: true,
+          } satisfies FileResponse
+        },
+      },
+      // Custom — returns void (no response body)
+      markRead: {
+        handler: () => undefined,
+      },
+    },
+  })
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [roleTable],
+      seed: [
+        'CREATE OR REPLACE VIEW role_view AS SELECT * FROM role',
+        "INSERT INTO role (id, slug) VALUES (1, 'admin')",
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  function mkApp(): ReturnType<typeof Fastify> {
+    const app = Fastify()
+    registerBoRoutes(app, testDb.db, {
+      bo: roleBO,
+      view: roleView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en', userId: 'user-123' }),
+    })
+    return app
+  }
+
+  it('registers POST /bo/{name}/{actionName} for each custom action', async () => {
+    const app = mkApp()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/bo/role/availableFragments',
+      payload: { scope: 'global' },
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toHaveLength(2)
+    expect(body[0].slug).toBe('MANAGE_STOCK')
+    expect(body[0].user).toBe('user-123')
+    expect(body[0].context).toEqual({ scope: 'global' })
+    await app.close()
+  })
+
+  it('passes the request body to the action as data', async () => {
+    const app = mkApp()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/bo/role/objectRefValues',
+      payload: { fieldSlug: 'WAREHOUSE', id: 42 },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ echoed: { fieldSlug: 'WAREHOUSE', id: 42 } })
+    await app.close()
+  })
+
+  it('does NOT register a /{actionName} route for standard create/update/delete', async () => {
+    const app = mkApp()
+    const res = await app.inject({ method: 'POST', url: '/bo/role/create', payload: {} })
+    expect(res.statusCode).toBe(404)
+    await app.close()
+  })
+
+  it('returns 204 when the action returns undefined', async () => {
+    const app = mkApp()
+    const res = await app.inject({ method: 'POST', url: '/bo/role/markRead', payload: {} })
+    expect(res.statusCode).toBe(204)
+    expect(res.body).toBe('')
+    await app.close()
+  })
+
+  it('sends binary when the action returns a FileResponse', async () => {
+    const app = mkApp()
+    const res = await app.inject({ method: 'POST', url: '/bo/role/pdf', payload: {} })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toBe('application/pdf')
+    expect(res.headers['content-disposition']).toBe('inline; filename="report.pdf"')
+    expect(res.headers['content-length']).toBe(String(Buffer.byteLength('%PDF-1.4 fake pdf content')))
+    expect(res.rawPayload.toString()).toBe('%PDF-1.4 fake pdf content')
+    await app.close()
+  })
+
+  it('defaults Content-Disposition to attachment when inline is false', async () => {
+    const testBO = defineBO(roleTable, {
+      paramField: 'id',
+      routePrefix: '/api/downloads',
+      actions: {
+        download: {
+          handler: () => ({
+            data: Buffer.from('hello'),
+            contentType: 'text/plain',
+            filename: 'hello.txt',
+          } satisfies FileResponse),
+        },
+      },
+    })
+    const app = Fastify()
+    registerBoRoutes(app, testDb.db, {
+      bo: testBO,
+      view: roleView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+    const res = await app.inject({ method: 'POST', url: '/bo/role/download', payload: {} })
+    expect(res.headers['content-disposition']).toBe('attachment; filename="hello.txt"')
+    await app.close()
+  })
+
+  it('works with an empty body', async () => {
+    const app = mkApp()
+    const res = await app.inject({ method: 'POST', url: '/bo/role/availableFragments' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toHaveLength(2)
+    await app.close()
+  })
+
+  it('returns a 500 when the action throws', async () => {
+    const throwingBO = defineBO(roleTable, {
+      paramField: 'id',
+      routePrefix: '/api/broken',
+      actions: {
+        broken: {
+          handler: () => { throw new Error('boom') },
+        },
+      },
+    })
+    const app = Fastify()
+    registerBoRoutes(app, testDb.db, {
+      bo: throwingBO,
+      view: roleView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+    const res = await app.inject({ method: 'POST', url: '/bo/role/broken', payload: {} })
+    expect(res.statusCode).toBe(500)
+    await app.close()
+  })
+})


### PR DESCRIPTION
## Summary

- Every non-standard action on a BO is auto-registered as **\`POST /bo/{boName}/{actionName}\`**. Request body → action's \`data\` argument. Standard \`create\` / \`update\` / \`delete\` keep their REST routes.
- Return-value handling:
  - Any value → JSON body, 200
  - \`undefined\` / \`null\` → 204 no body
  - New **\`FileResponse\`** shape (\`{ data: Buffer | Uint8Array, contentType, filename?, inline? }\`) → binary body with \`Content-Type\` + \`Content-Disposition\` headers
- \`FileResponse\` type exported from \`@pgbo/fastify\` — supports PDF/XLSX/CSV/etc.

Eliminates hand-written wrapper routes around \`bo.execute(...)\`.

Closes #5, closes #7.

## Test plan

- [x] \`tests/custom-actions.test.ts\` — 8 cases covering JSON, 204 void, file responses (inline + attachment), empty body, standard action NOT duplicated, throwing handler → 500
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm test\` clean across both packages
- [x] Changeset added (\`@pgbo/fastify\` minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)