### PR TITLE
feat(core): filtered compositions + request-scoped session params (closes #13, #14 core)

### DIFF
--- a/.changeset/composition-filters-and-session-params.md
+++ b/.changeset/composition-filters-and-session-params.md
@@ -1,0 +1,30 @@
+---
+"@pgbo/core": minor
+---
+
+Filtered composition children + request-scoped session parameters (closes #13, #14 core).
+
+### Issue #13 — Composition filters
+
+`CompositionDef` gains three new fields:
+
+- **`cardinality: 'many' | 'one'`** (default `'many'`). `'one'` returns a single object or `null`.
+- **`where`** — a WHERE clause applied to the composition query. Supports the same operators as `db.where()` plus context placeholders:
+  - `$locale` → `ctx.locale`
+  - `$userId` → `ctx.userId`
+  - `$tenantId` → `ctx.tenantId`
+  - `$now` → `new Date()`
+- **`merge: string[]`** — with `cardinality: 'one'`, lifts the matched child's fields onto the parent instead of attaching a nested object. Ideal for translations.
+
+`enrichCompositions(db, bo, items, { ctx })` gains an optional `ctx` option for placeholder resolution. If a placeholder references missing ctx data, enrichment throws (fail loud vs. silently returning unfiltered results).
+
+### Issue #14 — Request-scoped session parameters (Path B)
+
+- **`createDatabase({ sessionParams })`** — declare Postgres session parameters resolved from per-request `ctx`.
+- **`db.withContext(ctx, async tx => …)`** — open a scoped connection, emit `SET LOCAL <key> = <value>` for each configured param, run `fn` with a TransactionClient bound to that connection, commit on success (rolls back on error). Views can read the params via `current_setting('app.locale', true)`.
+
+Parameter names validated against `/^[A-Za-z][A-Za-z0-9_.]*$/` (injection guard). Values are escaped. Resolvers returning `undefined` / `null` are silently skipped (setting remains unset).
+
+### Deferred
+
+- The `.translatedJoin()` view helper from issue #14 is deferred to a follow-up — not needed for the core value prop (you can write the COALESCE JOIN SQL directly in a raw view for now).

--- a/docs/bo.md
+++ b/docs/bo.md
@@ -210,6 +210,71 @@ The function:
 4. Returns new objects — does not mutate the input
 5. Snake_case keys in child rows are converted to camelCase
 
+### Filtered compositions — cardinality, where, merge
+
+Compositions default to returning every matching child as an array (`cardinality: 'many'`). Three options change this:
+
+```typescript
+const areaBO = defineBO(areaTable, {
+  paramField: 'id',
+  compositions: {
+    // The one translation row matching the caller's locale
+    translation: {
+      table: areaTranslationTable,
+      parentKey: 'areaId',
+      cardinality: 'one',
+      where: { locale: '$locale' },
+    },
+    // Current contract — filter by validity window
+    currentContract: {
+      table: contractTable,
+      parentKey: 'customerId',
+      cardinality: 'one',
+      where: {
+        validFrom: { lte: '$now' },
+        validTo:   { gte: '$now' },
+      },
+    },
+    // Primary address — literal filter, no placeholder
+    primaryAddress: {
+      table: addressTable,
+      parentKey: 'customerId',
+      cardinality: 'one',
+      where: { isPrimary: 'yes' },
+    },
+  },
+})
+```
+
+**`cardinality`** — `'many'` (default, array) or `'one'` (single object or `null`).
+
+**`where`** — a WHERE clause applied to the composition query. Supports the same operators as `db.where()` (`lte`, `gte`, `ilike`, `any`, `in`, etc.) plus context placeholders:
+
+| Placeholder  | Resolved to   |
+|--------------|---------------|
+| `$locale`    | `ctx.locale`  |
+| `$userId`    | `ctx.userId`  |
+| `$tenantId`  | `ctx.tenantId`|
+| `$now`       | `new Date()`  |
+
+Pass `ctx` via `enrichCompositions(db, bo, items, { ctx })`. If a placeholder references ctx data that's missing, enrichment **throws** — failing loud beats silently returning unfiltered results.
+
+**`merge`** — with `cardinality: 'one'`, lifts the matched child's fields onto the parent instead of attaching a nested object. Common for translations:
+
+```typescript
+compositions: {
+  translation: {
+    table: areaTranslationTable,
+    parentKey: 'areaId',
+    cardinality: 'one',
+    where: { locale: '$locale' },
+    merge: ['name', 'description'],
+  },
+}
+
+// Result: { id, slug, name, description } — no nested 'translation' object
+```
+
 ### Nested Sub-Children
 
 Compositions can declare their own `children` for multi-level loading:

--- a/docs/query.md
+++ b/docs/query.md
@@ -338,6 +338,42 @@ await db.deleteFrom(areaView)
 await db.deleteFrom(warehouseView).all().execute()
 ```
 
+## Request-scoped context (`db.withContext`)
+
+Postgres has `current_setting('app.key', true)` for session-level config values. pgbo lets you bind those from a request `ctx` and use them directly in views — no code-level filtering needed.
+
+```typescript
+const db = createDatabase({
+  connectionString,
+  sessionParams: {
+    'app.locale':    (ctx) => ctx.locale,
+    'app.tenant_id': (ctx) => ctx.tenantId ?? '',
+    'app.user_id':   (ctx) => ctx.userId ?? '',
+  },
+})
+
+// Any view in the DB can now filter by these:
+// CREATE VIEW area_localized AS
+// SELECT a.id, a.slug, t.name
+// FROM area a
+// LEFT JOIN area_translation t
+//   ON t.area_id = a.id
+//  AND t.locale = current_setting('app.locale', true);
+
+// In the request handler:
+const rows = await db.withContext(req.user, async tx => {
+  return tx.from(areaLocalizedView).execute()
+})
+// → every query inside this scope sees app.locale / app.tenant_id / app.user_id
+//   exactly as resolved from req.user
+```
+
+`withContext` opens a dedicated connection, wraps everything in a transaction, emits `SET LOCAL` for each resolved param, runs `fn`, commits (or rolls back on error), and releases the connection. Zero per-query overhead — one transaction for the whole request.
+
+**The scoped client** — `tx` inside the callback is a `TransactionClient` with the same API as `db` (`from`, `into`, `update`, `deleteFrom`, `transaction`, `savepoint`, `query`, `raw`).
+
+**Safety** — resolver returning `undefined` or `null` skips that `SET LOCAL`. Parameter names are validated against `/^[A-Za-z][A-Za-z0-9_.]*$/` to prevent SQL injection via config. Values with single quotes are properly escaped.
+
 ## Transactions
 
 ```typescript

--- a/packages/pgbo/src/bo/enrich.ts
+++ b/packages/pgbo/src/bo/enrich.ts
@@ -1,48 +1,88 @@
-// Composition auto-enrichment for read operations (issue 018 + 019 nested)
+// Composition auto-enrichment for read operations
+// (issue #018 base + #019 nested children + #13 cardinality/where/merge)
 
 import type { Database } from '../query/client.js'
 import type { TableDef } from '../schema/definitions.js'
-import type { BusinessObjectDef, CompositionDef } from './types.js'
-import { toSnakeCase } from '../schema/table.js'
+import type { BusinessObjectDef, CompositionDef, ActionContext } from './types.js'
 import { toCamelCase } from '../query/select.js'
-
-function rowToCamelCase(row: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(row)) {
-    result[toCamelCase(key)] = value
-  }
-  return result
-}
+import type { WhereConditions } from '../query/where.js'
 
 function resolveTable(compDef: CompositionDef): TableDef | undefined {
   return compDef.table ?? compDef.view?.source
 }
 
+const PLACEHOLDER_PATTERN = /^\$(locale|userId|tenantId|now)$/
+
 /**
- * Load children for a set of parent rows, then recursively load sub-children.
+ * Replace `$locale` / `$userId` / `$tenantId` / `$now` string placeholders with
+ * resolved values. Throws if a placeholder references ctx data that is missing —
+ * failing loud is safer than silently returning unfiltered results.
  */
+function resolvePlaceholder(value: unknown, ctx: ActionContext | undefined): unknown {
+  if (typeof value !== 'string') return value
+  const match = PLACEHOLDER_PATTERN.exec(value)
+  const key = match?.[1]
+  if (!key) return value
+  if (key === 'now') return new Date()
+  if (!ctx) {
+    throw new Error(`Composition where uses "${value}" but enrichCompositions was called without a ctx`)
+  }
+  const resolved = (ctx as Record<string, unknown>)[key]
+  if (resolved === undefined) {
+    throw new Error(`Composition where uses "${value}" but ctx.${key} is undefined`)
+  }
+  return resolved
+}
+
+/** Recursively resolve placeholders in a WHERE clause (including nested operators). */
+function resolveWhere(where: Record<string, unknown>, ctx: ActionContext | undefined): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(where)) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
+      // Operator object like { lte: '$now' } or nested AND/OR
+      resolved[key] = resolveWhere(value as Record<string, unknown>, ctx)
+    } else if (Array.isArray(value)) {
+      resolved[key] = value.map(v => resolvePlaceholder(v, ctx))
+    } else {
+      resolved[key] = resolvePlaceholder(value, ctx)
+    }
+  }
+  return resolved
+}
+
+export interface EnrichOptions {
+  /** Context used to resolve `$locale` / `$userId` / `$tenantId` placeholders in `where`. */
+  readonly ctx?: ActionContext
+}
+
 async function loadCompositionLevel(
   db: Database,
   compositions: readonly (readonly [string, CompositionDef])[],
   parentKeyField: string,
   items: readonly Record<string, unknown>[],
-): Promise<Map<string, Map<unknown, Record<string, unknown>[]>>> {
-  if (compositions.length === 0 || items.length === 0) {
-    return new Map()
-  }
+  opts: EnrichOptions,
+): Promise<Map<string, { def: CompositionDef; grouped: Map<unknown, Record<string, unknown>[]> }>> {
+  const resultMap = new Map<string, { def: CompositionDef; grouped: Map<unknown, Record<string, unknown>[]> }>()
+  if (compositions.length === 0 || items.length === 0) return resultMap
 
   const parentIds = items.map(item => item[parentKeyField])
 
   const results = await Promise.all(
     compositions.map(async ([compName, compDef]) => {
       const compTable = resolveTable(compDef)
-      if (!compTable) return { compName, grouped: new Map<unknown, Record<string, unknown>[]>() }
+      if (!compTable) return { compName, def: compDef, grouped: new Map<unknown, Record<string, unknown>[]>() }
 
-      const snakeParentKey = toSnakeCase(compDef.parentKey)
-      const sql = `SELECT * FROM ${compTable.name} WHERE ${snakeParentKey} = ANY($1)`
-      const rows = await db.query(sql, [parentIds])
+      // Build WHERE: parent_key = ANY(ids), plus any resolved filter clause.
+      const where: WhereConditions = {
+        [compDef.parentKey]: { any: parentIds },
+      }
+      if (compDef.where) {
+        const resolved = resolveWhere(compDef.where, opts.ctx)
+        for (const [k, v] of Object.entries(resolved)) where[k] = v
+      }
 
-      const camelRows = rows.map(rowToCamelCase)
+      const rows = await db._table.from(compTable).where(where).execute()
+      const camelRows = rows as unknown as Record<string, unknown>[]
 
       // Group by parent key
       const grouped = new Map<unknown, Record<string, unknown>[]>()
@@ -58,33 +98,38 @@ async function loadCompositionLevel(
 
       // Recursively load sub-children
       if (compDef.children && Object.keys(compDef.children).length > 0 && camelRows.length > 0) {
-        // Determine the child's primary key — use the child table's primaryKey[0]
         const childPK = compTable.primaryKey[0]
         if (childPK) {
           const childPKCamel = toCamelCase(childPK)
           const childCompositions = Object.entries(compDef.children) as (readonly [string, CompositionDef])[]
 
-          const subResults = await loadCompositionLevel(db, childCompositions, childPKCamel, camelRows)
+          const subResults = await loadCompositionLevel(db, childCompositions, childPKCamel, camelRows, opts)
 
-          // Attach sub-children to child rows
           for (const row of camelRows) {
             const childId = row[childPKCamel]
-            for (const [subName, subGrouped] of subResults) {
-              row[subName] = subGrouped.get(childId) ?? []
+            for (const [subName, { def: subDef, grouped: subGrouped }] of subResults) {
+              row[subName] = shapeChildren(subDef, subGrouped.get(childId) ?? [])
             }
           }
         }
       }
 
-      return { compName, grouped }
+      return { compName, def: compDef, grouped }
     }),
   )
 
-  const resultMap = new Map<string, Map<unknown, Record<string, unknown>[]>>()
-  for (const { compName, grouped } of results) {
-    resultMap.set(compName, grouped)
+  for (const { compName, def, grouped } of results) {
+    resultMap.set(compName, { def, grouped })
   }
   return resultMap
+}
+
+/** Apply cardinality + merge semantics to the children for one parent row. */
+function shapeChildren(def: CompositionDef, children: Record<string, unknown>[]): unknown {
+  if (def.cardinality === 'one') {
+    return children[0] ?? null
+  }
+  return children
 }
 
 /**
@@ -92,9 +137,9 @@ async function loadCompositionLevel(
  *
  * For each composition defined on the BO:
  * 1. Collect parent key values from `items` using `bo.paramField`
- * 2. SELECT * FROM comp_table WHERE parent_key = ANY($1)
- * 3. If the composition has `children`, recursively load sub-children
- * 4. Group by parent key, attach as nested array under the composition name
+ * 2. SELECT from comp table WHERE parent_key = ANY($1) [AND <resolved where>]
+ * 3. If `children`, recursively load sub-children
+ * 4. Apply `cardinality` / `merge` / attach to parent
  *
  * Returns new objects — does not mutate the input array.
  */
@@ -102,20 +147,38 @@ export async function enrichCompositions<T extends Record<string, unknown>>(
   db: Database,
   bo: BusinessObjectDef,
   items: readonly T[],
-): Promise<(T & Record<string, unknown[]>)[]> {
+  opts: EnrichOptions = {},
+): Promise<T[]> {
   const compositions = Object.entries(bo.compositions) as (readonly [string, CompositionDef])[]
   if (compositions.length === 0 || items.length === 0) {
-    return items.map(item => ({ ...item }) as T & Record<string, unknown[]>)
+    return items.map(item => ({ ...item }))
   }
 
-  const resultMap = await loadCompositionLevel(db, compositions, bo.paramField, items as readonly Record<string, unknown>[])
+  const resultMap = await loadCompositionLevel(
+    db,
+    compositions,
+    bo.paramField,
+    items as readonly Record<string, unknown>[],
+    opts,
+  )
 
   return items.map(item => {
     const enriched: Record<string, unknown> = { ...item }
     const parentValue = item[bo.paramField]
-    for (const [compName, grouped] of resultMap) {
-      enriched[compName] = grouped.get(parentValue) ?? []
+    for (const [compName, { def, grouped }] of resultMap) {
+      const children = grouped.get(parentValue) ?? []
+      if (def.cardinality === 'one' && def.merge && def.merge.length > 0) {
+        // Lift merge fields onto parent instead of attaching as an object
+        const match = children[0]
+        if (match) {
+          for (const field of def.merge) enriched[field] = match[field]
+        } else {
+          for (const field of def.merge) enriched[field] = null
+        }
+      } else {
+        enriched[compName] = shapeChildren(def, children)
+      }
     }
-    return enriched as T & Record<string, unknown[]>
+    return enriched as T
   })
 }

--- a/packages/pgbo/src/bo/types.ts
+++ b/packages/pgbo/src/bo/types.ts
@@ -17,6 +17,22 @@ export interface CompositionDef {
   readonly table?: TableDef
   readonly parentKey: string
   readonly children?: Readonly<Record<string, CompositionDef>>
+  /**
+   * `'many'` (default) — return all matching children as an array.
+   * `'one'` — return a single object or `null`, filtered via `where`.
+   */
+  readonly cardinality?: 'many' | 'one'
+  /**
+   * Optional WHERE clause applied to the composition query. Values may be
+   * literal or context placeholders: `$locale` / `$userId` / `$tenantId` / `$now`.
+   */
+  readonly where?: Record<string, unknown>
+  /**
+   * With `cardinality: 'one'`, lifts these fields from the matched child onto
+   * the parent instead of attaching the child as a nested object.
+   * Commonly used for translations: `merge: ['name', 'description']`.
+   */
+  readonly merge?: readonly string[]
 }
 
 export interface VirtualFieldMeta {

--- a/packages/pgbo/src/query/client.ts
+++ b/packages/pgbo/src/query/client.ts
@@ -8,7 +8,7 @@ import { SelectBuilder } from './select.js'
 import { InsertBuilder } from './insert.js'
 import { UpdateBuilder } from './update.js'
 import { DeleteBuilder } from './delete.js'
-import { runTransaction, type TransactionClient } from './transaction.js'
+import { runTransaction, runContextualTransaction, type TransactionClient } from './transaction.js'
 import type { CacheProvider } from './cache.js'
 
 export type AuthHandler = (userId: string, restriction: Restriction) => Promise<boolean> | boolean
@@ -30,6 +30,9 @@ function makeAuthCheck(handler: AuthHandler, restriction: Restriction, viewName:
   }
 }
 
+/** Resolver for a session parameter. Called with the request `ctx` inside `db.withContext()`. */
+export type SessionParamResolver = (ctx: Record<string, unknown>) => string | number | boolean | null | undefined
+
 export interface DatabaseConfig {
   connectionString: string
   pool?: {
@@ -40,6 +43,12 @@ export interface DatabaseConfig {
   }
   /** Optional cache provider. Enables `.cached()` on queries and auto-invalidation on BO writes. */
   cache?: CacheProvider
+  /**
+   * Postgres session parameters (`SET LOCAL <key> = <value>`) emitted at the start
+   * of every `db.withContext(ctx, ...)` scope. Values are resolved per-request from ctx.
+   * Views can read these with `current_setting('app.locale', true)`.
+   */
+  sessionParams?: Record<string, SessionParamResolver>
 }
 
 /** Internal table-level operations — used by framework internals (BO actions, seeds, testing) */
@@ -91,6 +100,14 @@ export interface Database extends Queryable {
 
   /** Run a callback in a transaction with auto-rollback on error */
   transaction<T>(fn: (tx: TransactionClient) => Promise<T>): Promise<T>
+
+  /**
+   * Open a scoped connection, emit `SET LOCAL` for each configured `sessionParams`
+   * resolved from `ctx`, then run `fn` with a `TransactionClient` bound to that
+   * connection. All queries inside the scope see the session parameters via
+   * `current_setting('app.key', true)`. Commits on success, rolls back on error.
+   */
+  withContext<T>(ctx: Record<string, unknown>, fn: (scoped: TransactionClient) => Promise<T>): Promise<T>
 
   /** Execute a raw SQL tagged template */
   raw<T extends Record<string, unknown> = Record<string, unknown>>(
@@ -196,6 +213,16 @@ export function createDatabase(config: DatabaseConfig): Database {
 
     async transaction<T>(fn: (tx: TransactionClient) => Promise<T>): Promise<T> {
       return runTransaction(pool, fn, authHandler)
+    },
+
+    async withContext<T>(ctx: Record<string, unknown>, fn: (scoped: TransactionClient) => Promise<T>): Promise<T> {
+      const resolvers = config.sessionParams ?? {}
+      const resolved: Record<string, string | number | boolean | null> = {}
+      for (const [key, resolver] of Object.entries(resolvers)) {
+        const value = resolver(ctx)
+        if (value !== undefined) resolved[key] = value
+      }
+      return runContextualTransaction(pool, fn, resolved, authHandler)
     },
 
     async raw<T extends Record<string, unknown> = Record<string, unknown>>(

--- a/packages/pgbo/src/query/index.ts
+++ b/packages/pgbo/src/query/index.ts
@@ -1,5 +1,5 @@
 export { createDatabase } from './client.js'
-export type { Database, DatabaseConfig, TableOps, AuthHandler } from './client.js'
+export type { Database, DatabaseConfig, TableOps, AuthHandler, SessionParamResolver } from './client.js'
 export type { Queryable } from './types.js'
 export { SelectBuilder, toCamelCase } from './select.js'
 export type { QuerySpec } from './select.js'

--- a/packages/pgbo/src/query/transaction.ts
+++ b/packages/pgbo/src/query/transaction.ts
@@ -145,3 +145,43 @@ export async function runTransaction<T>(
     client.release()
   }
 }
+
+/**
+ * Like `runTransaction` but emits `SET LOCAL <key> = <value>` for each entry
+ * in `sessionParams` immediately after BEGIN, before handing the scoped client
+ * to `fn`. Used by `db.withContext(ctx, fn)`.
+ *
+ * Parameter keys are validated (letters, digits, `.`, `_`) to prevent SQL
+ * injection via config — user-provided values are bound as parameters.
+ */
+export async function runContextualTransaction<T>(
+  pool: pg.Pool,
+  fn: (tx: TransactionClient) => Promise<T>,
+  sessionParams: Record<string, string | number | boolean | null>,
+  authHandler?: AuthHandler,
+): Promise<T> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+
+    for (const [rawKey, value] of Object.entries(sessionParams)) {
+      if (!/^[A-Za-z][A-Za-z0-9_.]*$/.test(rawKey)) {
+        throw new Error(`Invalid session parameter name "${rawKey}" — must match /^[A-Za-z][A-Za-z0-9_.]*$/`)
+      }
+      if (value === null) continue
+      // pg driver doesn't support bind params in SET, so stringify + single-quote-escape
+      const str = String(value).replaceAll("'", "''")
+      await client.query(`SET LOCAL ${rawKey} = '${str}'`)
+    }
+
+    const tx = createTransactionClient(client, authHandler)
+    const result = await fn(tx)
+    await client.query('COMMIT')
+    return result
+  } catch (err) {
+    await client.query('ROLLBACK')
+    throw err
+  } finally {
+    client.release()
+  }
+}

--- a/packages/pgbo/tests/bo/enrich-cardinality.test.ts
+++ b/packages/pgbo/tests/bo/enrich-cardinality.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { view } from '../../src/schema/view.js'
+import { text, integer, timestamp } from '../../src/schema/types.js'
+import { foreignKey } from '../../src/schema/constraints.js'
+import { defineBO } from '../../src/bo/index.js'
+import { enrichCompositions } from '../../src/bo/enrich.js'
+import { createTestDatabase, type TestDatabase } from '../../src/testing/database.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const areaTable = table('area', {
+  columns: { id: integer().notNull(), slug: text().notNull() },
+  primaryKey: ['id'],
+})
+
+const areaTranslationTable = table('area_translation', {
+  columns: {
+    areaId: integer().notNull(),
+    locale: text().notNull(),
+    name: text().notNull(),
+  },
+  primaryKey: ['areaId', 'locale'],
+  foreignKeys: [foreignKey(['areaId']).references('area', ['id']).onDelete('CASCADE')],
+})
+
+const addressTable = table('address', {
+  columns: {
+    id: integer().notNull(),
+    customerId: integer().notNull(),
+    label: text().notNull(),
+    isPrimary: text(),  // 'yes' / null; avoids PG reserved keyword "primary"
+  },
+  primaryKey: ['id'],
+})
+
+const customerTable = table('customer', {
+  columns: { id: integer().notNull(), name: text().notNull() },
+  primaryKey: ['id'],
+})
+
+const contractTable = table('contract', {
+  columns: {
+    id: integer().notNull(),
+    customerId: integer().notNull(),
+    validFrom: timestamp().withTimeZone().notNull(),
+    validTo: timestamp().withTimeZone().notNull(),
+    plan: text().notNull(),
+  },
+  primaryKey: ['id'],
+})
+
+const areaView = view('area_view').from(areaTable)
+const customerView = view('customer_view').from(customerTable)
+
+describe('Composition cardinality + where + merge (issue #13)', () => {
+  let testDb: TestDatabase
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [areaTable, areaTranslationTable, customerTable, addressTable, contractTable],
+      seed: [
+        'CREATE OR REPLACE VIEW area_view AS SELECT * FROM area',
+        'CREATE OR REPLACE VIEW customer_view AS SELECT * FROM customer',
+        "INSERT INTO area (id, slug) VALUES (1, 'nav'), (2, 'admin')",
+        "INSERT INTO area_translation (area_id, locale, name) VALUES (1, 'en', 'Navigation'), (1, 'de', 'Navigation DE'), (2, 'en', 'Admin')",
+        "INSERT INTO customer (id, name) VALUES (10, 'Alice'), (20, 'Bob')",
+        "INSERT INTO address (id, customer_id, label, is_primary) VALUES (100, 10, 'Home', 'yes'), (101, 10, 'Work', null), (102, 20, 'Office', 'yes')",
+        "INSERT INTO contract (id, customer_id, valid_from, valid_to, plan) VALUES (200, 10, '2024-01-01', '2025-01-01', 'basic'), (201, 10, '2025-01-01', '2030-01-01', 'pro'), (202, 20, '2024-01-01', '2030-01-01', 'enterprise')",
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  describe('cardinality: "one"', () => {
+    it('returns a single object or null', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          primaryTranslation: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+            cardinality: 'one',
+            where: { locale: 'en' },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).orderBy('id', 'asc').execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items)
+
+      expect(enriched[0]!.primaryTranslation).toMatchObject({ locale: 'en', name: 'Navigation' })
+      expect(enriched[1]!.primaryTranslation).toMatchObject({ locale: 'en', name: 'Admin' })
+    })
+
+    it('returns null when no row matches', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          frenchTranslation: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+            cardinality: 'one',
+            where: { locale: 'fr' },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items)
+      expect(enriched[0]!.frenchTranslation).toBeNull()
+    })
+  })
+
+  describe('where with $locale context placeholder', () => {
+    it('resolves $locale from ctx', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          translation: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+            cardinality: 'one',
+            where: { locale: '$locale' },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).orderBy('id', 'asc').execute()
+
+      const en = await enrichCompositions(testDb.db, bo, items, { ctx: { locale: 'en' } })
+      expect((en[0]!.translation as any).name).toBe('Navigation')
+
+      const de = await enrichCompositions(testDb.db, bo, items, { ctx: { locale: 'de' } })
+      expect((de[0]!.translation as any).name).toBe('Navigation DE')
+    })
+
+    it('throws when placeholder references missing ctx data (fail loud)', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          translation: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+            cardinality: 'one',
+            where: { locale: '$locale' },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).execute()
+      await expect(enrichCompositions(testDb.db, bo, items, {})).rejects.toThrow(
+        /uses "\$locale" but enrichCompositions was called without a ctx/,
+      )
+      await expect(enrichCompositions(testDb.db, bo, items, { ctx: {} })).rejects.toThrow(
+        /uses "\$locale" but ctx\.locale is undefined/,
+      )
+    })
+  })
+
+  describe('where with $now placeholder', () => {
+    it('filters by current time for current-contract pattern', async () => {
+      const bo = defineBO(customerTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          currentContract: {
+            table: contractTable,
+            parentKey: 'customerId',
+            cardinality: 'one',
+            where: {
+              validFrom: { lte: '$now' },
+              validTo: { gte: '$now' },
+            },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(customerView).orderBy('id', 'asc').execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items)
+
+      // Alice (id 10): two contracts, only the 2025-2030 one covers $now (2026)
+      expect((enriched[0]!.currentContract as any).plan).toBe('pro')
+      // Bob (id 20): one contract, enterprise
+      expect((enriched[1]!.currentContract as any).plan).toBe('enterprise')
+    })
+  })
+
+  describe('merge: lift fields onto parent', () => {
+    it('attaches translation.name as parent.name (no nested object)', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          translation: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+            cardinality: 'one',
+            where: { locale: '$locale' },
+            merge: ['name'],
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).orderBy('id', 'asc').execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items, { ctx: { locale: 'en' } })
+
+      expect(enriched[0]!).toMatchObject({ id: 1, slug: 'nav', name: 'Navigation' })
+      expect(enriched[1]!).toMatchObject({ id: 2, slug: 'admin', name: 'Admin' })
+      // No nested 'translation' object
+      expect((enriched[0] as any).translation).toBeUndefined()
+    })
+
+    it('merge with no matching row sets fields to null', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          translation: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+            cardinality: 'one',
+            where: { locale: 'fr' },
+            merge: ['name'],
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items)
+      expect((enriched[0] as any).name).toBeNull()
+    })
+  })
+
+  describe('cardinality: "many" (default, unchanged behaviour)', () => {
+    it('returns an array', async () => {
+      const bo = defineBO(areaTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          translations: {
+            table: areaTranslationTable,
+            parentKey: 'areaId',
+          },
+        },
+      })
+
+      const items = await testDb.db.from(areaView).where({ id: 1 }).execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items)
+
+      expect(enriched[0]!.translations).toHaveLength(2)
+    })
+  })
+
+  describe('where with boolean/string literals', () => {
+    it('supports static WHERE filters (no placeholders)', async () => {
+      const bo = defineBO(customerTable, {
+        paramField: 'id',
+        actions: { create: {} },
+        compositions: {
+          primaryAddress: {
+            table: addressTable,
+            parentKey: 'customerId',
+            cardinality: 'one',
+            where: { isPrimary: 'yes' },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(customerView).orderBy('id', 'asc').execute()
+      const enriched = await enrichCompositions(testDb.db, bo, items)
+
+      expect((enriched[0]!.primaryAddress as any).label).toBe('Home')
+      expect((enriched[1]!.primaryAddress as any).label).toBe('Office')
+    })
+  })
+})

--- a/packages/pgbo/tests/query/with-context.test.ts
+++ b/packages/pgbo/tests/query/with-context.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { view } from '../../src/schema/view.js'
+import { text, integer } from '../../src/schema/types.js'
+import { createTestDatabase, type TestDatabase } from '../../src/testing/database.js'
+import { createDatabase } from '../../src/query/client.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const areaTable = table('area', {
+  columns: { id: integer().notNull(), slug: text().notNull() },
+  primaryKey: ['id'],
+})
+
+const areaTranslationTable = table('area_translation', {
+  columns: {
+    areaId: integer().notNull(),
+    locale: text().notNull(),
+    name: text().notNull(),
+  },
+  primaryKey: ['areaId', 'locale'],
+})
+
+// View that uses current_setting('app.locale', true) to filter translations per request
+const areaLocalizedView = view('area_localized').from(areaTable)
+
+describe('db.withContext + sessionParams (issue #14)', () => {
+  let testDb: TestDatabase
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [areaTable, areaTranslationTable],
+      seed: [
+        `CREATE OR REPLACE VIEW area_localized AS
+         SELECT a.id, a.slug, t.name
+         FROM area a
+         LEFT JOIN area_translation t
+           ON t.area_id = a.id
+          AND t.locale = current_setting('app.locale', true)`,
+        "INSERT INTO area (id, slug) VALUES (1, 'nav'), (2, 'admin')",
+        "INSERT INTO area_translation (area_id, locale, name) VALUES (1, 'en', 'Navigation'), (1, 'de', 'Navigation DE'), (2, 'en', 'Admin'), (2, 'de', 'Verwaltung')",
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  it('withContext emits SET LOCAL for each configured sessionParam', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: {
+        'app.locale': (ctx) => (ctx as { locale?: string }).locale ?? 'en',
+      },
+    })
+
+    const rowsEn = await db.withContext({ locale: 'en' }, async tx => {
+      return tx.from(areaLocalizedView).orderBy('id', 'asc').execute()
+    })
+    expect(rowsEn.map(r => r.name)).toEqual(['Navigation', 'Admin'])
+
+    const rowsDe = await db.withContext({ locale: 'de' }, async tx => {
+      return tx.from(areaLocalizedView).orderBy('id', 'asc').execute()
+    })
+    expect(rowsDe.map(r => r.name)).toEqual(['Navigation DE', 'Verwaltung'])
+
+    await db.close()
+  })
+
+  it('without withContext, current_setting returns NULL → no translations match', async () => {
+    const db = createDatabase({ connectionString: testDb.connectionString })
+    const rows = await db.from(areaLocalizedView).orderBy('id', 'asc').execute()
+    expect(rows.every(r => r.name === null)).toBe(true)
+    await db.close()
+  })
+
+  it('supports multiple session params', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: {
+        'app.locale': (ctx) => (ctx as { locale?: string }).locale ?? 'en',
+        'app.tenant_id': (ctx) => (ctx as { tenantId?: string }).tenantId ?? '',
+      },
+    })
+
+    const result = await db.withContext({ locale: 'de', tenantId: 't1' }, async tx => {
+      const r = await tx.query<{ locale: string; tenant: string }>(
+        `SELECT current_setting('app.locale', true) AS locale, current_setting('app.tenant_id', true) AS tenant`,
+      )
+      return r[0]
+    })
+    expect(result).toEqual({ locale: 'de', tenant: 't1' })
+    await db.close()
+  })
+
+  it('resolvers returning undefined skip the SET LOCAL entirely', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: {
+        'app.locale': (ctx) => (ctx as { locale?: string }).locale,  // undefined when not in ctx
+      },
+    })
+
+    // current_setting returns NULL when setting is unset (missing_ok=true)
+    const got = await db.withContext({}, async tx => {
+      const r = await tx.query<{ val: string | null }>(`SELECT current_setting('app.locale', true) AS val`)
+      return r[0]?.val
+    })
+    expect(got).toBeNull()
+    await db.close()
+  })
+
+  it('resolvers returning null skip the SET LOCAL entirely', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: {
+        'app.locale': () => null,
+      },
+    })
+    const got = await db.withContext({}, async tx => {
+      const r = await tx.query<{ val: string | null }>(`SELECT current_setting('app.locale', true) AS val`)
+      return r[0]?.val
+    })
+    expect(got).toBeNull()
+    await db.close()
+  })
+
+  it('rolls back on error (SET LOCAL leaks prevented)', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: { 'app.locale': () => 'fr' },
+    })
+    await expect(
+      db.withContext({}, async () => { throw new Error('boom') }),
+    ).rejects.toThrow('boom')
+
+    // After rollback, the setting is not set — Postgres returns NULL or '' for custom settings
+    // depending on whether the session ever "declared" it. Either way, it's not 'fr'.
+    const got = await db.query<{ val: string | null }>(`SELECT current_setting('app.locale', true) AS val`)
+    expect(got[0]?.val ?? '').not.toBe('fr')
+    await db.close()
+  })
+
+  it('rejects invalid parameter names (injection guard)', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: { 'bad; DROP TABLE users': () => 'x' },
+    })
+    await expect(
+      db.withContext({}, async () => undefined),
+    ).rejects.toThrow(/Invalid session parameter name/)
+    await db.close()
+  })
+
+  it('escapes single quotes in values', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: { 'app.locale': () => "en'; DROP TABLE area; --" },
+    })
+    const got = await db.withContext({}, async tx => {
+      const r = await tx.query<{ val: string }>(`SELECT current_setting('app.locale', true) AS val`)
+      return r[0]?.val
+    })
+    expect(got).toBe("en'; DROP TABLE area; --")
+    // Area table should still exist
+    const rows = await db.query<{ count: string }>('SELECT COUNT(*) AS count FROM area')
+    expect(Number(rows[0]!.count)).toBe(2)
+    await db.close()
+  })
+
+  it('numeric and boolean param values work', async () => {
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: {
+        'app.level': () => 42,
+        'app.enabled': () => true,
+      },
+    })
+    const got = await db.withContext({}, async tx => {
+      const r = await tx.query<{ l: string; e: string }>(
+        `SELECT current_setting('app.level', true) AS l, current_setting('app.enabled', true) AS e`,
+      )
+      return r[0]
+    })
+    expect(got).toEqual({ l: '42', e: 'true' })
+    await db.close()
+  })
+})


### PR DESCRIPTION
## Summary

### Issue #13 — Composition filters

\`CompositionDef\` gains three new fields:

- **\`cardinality: 'many' | 'one'\`** — \`'one'\` returns a single object or \`null\`.
- **\`where\`** — filter clause with context placeholders (\`\$locale\` / \`\$userId\` / \`\$tenantId\` / \`\$now\`).
- **\`merge: string[]\`** — lifts matched child fields onto the parent (translation pattern).

\`enrichCompositions(db, bo, items, { ctx })\` gains an optional \`ctx\`. Missing placeholder data throws (fail loud).

### Issue #14 — Session parameters (Path B: explicit request scope)

- **\`createDatabase({ sessionParams })\`** — declare Postgres session params resolved from per-request \`ctx\`.
- **\`db.withContext(ctx, async tx => …)\`** — scoped transaction that emits \`SET LOCAL ...\` for each param. Views read via \`current_setting('app.locale', true)\`. Zero per-query overhead.

Name regex guard + single-quote escaping (injection-safe). \`undefined\`/\`null\` resolver results skip the SET LOCAL.

### Deferred

The \`.translatedJoin()\` view helper from #14 is a follow-up — not needed for the core value prop; users can write the COALESCE SQL in a raw view.

## Design decision

For #14 we chose **Path B** (explicit \`withContext\` scope) over Path A (implicit transaction per query) to avoid hidden BEGIN/COMMIT overhead on every query. Matches \`db.transaction()\`'s existing pattern.

## Test plan

- [x] \`tests/bo/enrich-cardinality.test.ts\` — 9 cases: cardinality:'one', placeholder resolution for \$locale/\$now, merge semantics, primary filter, fail-loud on missing ctx
- [x] \`tests/query/with-context.test.ts\` — 9 cases: SET LOCAL emission, multi-param, rollback isolation, injection guard, quote escaping, numeric/boolean values
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm test\` — 376 total tests pass across both packages
- [x] Changeset added (\`@pgbo/core\` minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)