### PR TITLE
ci: test on Node 22 + 24 (drop Node 20)

### DIFF
--- a/.changeset/bump-node-min-to-22.md
+++ b/.changeset/bump-node-min-to-22.md
@@ -1,0 +1,8 @@
+---
+"@pgbo/core": minor
+"@pgbo/fastify": minor
+---
+
+Bump minimum supported Node version from 20 to 22.
+
+CI matrix now runs against Node 22 and 24 (was 20 and 22). Node 20 is in maintenance LTS; Node 22 is the current active LTS. This aligns the supported range with npm's Trusted Publishing requirement (npm 11.5+, bundled with Node 22+) and lets us use modern features without polyfills.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22']
+        node: ['22', '24']
 
     services:
       postgres:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:preview": "vitepress preview docs"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/packages/pgbo-fastify/package.json
+++ b/packages/pgbo-fastify/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/tim-riep/pgbo#readme",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@pgbo/core": "0.2.0"

--- a/packages/pgbo/package.json
+++ b/packages/pgbo/package.json
@@ -85,7 +85,7 @@
   },
   "homepage": "https://github.com/tim-riep/pgbo#readme",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "pg": "^8.16.0"


### PR DESCRIPTION
## Summary

- CI matrix: Node 20/22 → **Node 22/24**
- \`engines.node\`: \`>=20\` → \`>=22\` on root + both packages

## Rationale

- Node 20 is in maintenance LTS; Node 22 is the current active LTS.
- Aligns the supported range with npm 11.5+ (bundled with Node 22+), which is what Trusted Publishing requires — so we don't advertise support for versions where our own publish path wouldn't work.

## Test plan

- [x] Locally green on Node 24 (lint + typecheck + 358 tests)
- [x] Changeset added (\`@pgbo/core\` + \`@pgbo/fastify\` minor — \`engines.node\` is publicly visible metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)