### PR TITLE
feat!: BO projections as the HTTP surface (closes #15 core)

### DIFF
--- a/.changeset/bo-projections.md
+++ b/.changeset/bo-projections.md
@@ -1,0 +1,48 @@
+---
+"@pgbo/core": minor
+"@pgbo/fastify": major
+---
+
+Introduce BO projections as the HTTP surface (closes #15 core).
+
+**Breaking change in `@pgbo/fastify`**: `registerBoRoutes` is replaced by `registerProjection`. BOs are no longer directly exposed to HTTP — you must first wrap them in a projection that explicitly whitelists which actions and columns are reachable.
+
+### New in `@pgbo/core`
+
+- `defineProjection(bo, { name, actions, columns?, where? })` — declare an HTTP surface over a BO
+- `projectRow(projection, row)` / `projectionExposes(projection, action)` — helpers
+- `ProjectionDef` / `ProjectionConfig` types exported from `@pgbo/core/bo`
+
+### New in `@pgbo/fastify`
+
+- `registerProjection(app, db, config)` replaces `registerBoRoutes`
+- `ProjectionRouteConfig` replaces `BoRouteConfig` (same fields but takes `projection` instead of `bo`)
+- Only whitelisted actions produce routes — missing an action from the projection means missing routes, not forbidden routes
+- Root WHERE on the projection applies to every list / detail / update / delete; out-of-scope rows 404
+- `columns` narrows both response bodies and the metadata endpoint
+
+### Migration
+
+Wrap every BO in a one-shot projection that reproduces today's behaviour, then refine per surface:
+
+```ts
+// Before
+registerBoRoutes(app, db, { bo: warehouseBO, view: warehouseView, extractContext })
+
+// After — full surface
+const warehouseAll = defineProjection(warehouseBO, {
+  name: 'warehouse',
+  actions: { read: true, create: true, update: true, delete: true },
+})
+registerProjection(app, db, { projection: warehouseAll, view: warehouseView, extractContext })
+
+// Or split by audience — admin vs public
+const warehousePublic = defineProjection(warehouseBO, { name: 'warehousePublic', actions: { read: true }, columns: ['id', 'slug', 'name'] })
+const warehouseAdmin  = defineProjection(warehouseBO, { name: 'warehouseAdmin',  actions: { read: true, create: true, update: true, delete: true } })
+```
+
+### Deferred to follow-up PRs
+
+- Filtered compositions/associations overrides on the projection (depends on PR #16 already-merged vocabulary)
+- Locked context values (`lock: { locale: '$locale' }`)
+- Projection-of-projection composability

--- a/docs/bo.md
+++ b/docs/bo.md
@@ -2,6 +2,8 @@
 
 A Business Object (BO) is a managed entity that wraps a view with CRUD lifecycle, permission checks, and hooks. BOs are **read-only by default** — you must explicitly define actions to enable writes.
 
+**BOs are not exposed to HTTP directly.** Any HTTP surface goes through a [**Projection**](#projections) — an explicit whitelist of actions and columns. BOs stay importable for custom action handlers, CLI scripts, and internal use; projections are the only thing wired to `registerProjection` in `@pgbo/fastify`.
+
 ## Defining a BO
 
 ```typescript
@@ -338,3 +340,92 @@ const productBO = defineBO(productTable, {
   },
 })
 ```
+
+## Projections
+
+A projection is the HTTP surface layered on top of a BO. The BO holds the data model and write logic; the projection declares **exactly** what is reachable over HTTP — which actions are whitelisted, which columns are visible, and what root-level WHERE applies to every query.
+
+```typescript
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+
+const areaBO = defineBO(areaTable, {
+  paramField: 'id',
+  actions: {
+    create: {}, update: {}, delete: {},
+    rebuildCache: { handler: async () => { /* ... */ } },
+    internalExport: { handler: async () => { /* ... */ } },
+  },
+})
+
+// Public read-only surface
+const areaPublic = defineProjection(areaBO, {
+  name: 'areaPublic',
+  actions: { read: true },
+  columns: ['id', 'slug', 'name'],  // internal columns hidden
+})
+
+// Admin surface — CRUD + one custom action, but NOT internalExport
+const areaAdmin = defineProjection(areaBO, {
+  name: 'areaAdmin',
+  actions: { read: true, create: true, update: true, delete: true, rebuildCache: true },
+})
+```
+
+### Explicit action whitelist
+
+Only actions listed with `true` produce routes. Standard keys:
+
+| Key        | Routes registered                         |
+|------------|-------------------------------------------|
+| `read`     | `GET {prefix}`, `GET {prefix}/:param`, `GET /bo/{name}` |
+| `create`   | `POST {prefix}`                           |
+| `update`   | `PUT {prefix}/:param`                     |
+| `delete`   | `DELETE {prefix}/:param`                  |
+| `<custom>` | `POST /bo/{name}/{custom}`                |
+
+Actions not mentioned in the whitelist produce no routes. Accidentally adding an action to the BO **does not** expose it — it must be explicitly whitelisted on every projection.
+
+### Column narrowing
+
+When `columns` is set, responses and the metadata endpoint return only those fields. Fields absent from the projection are invisible to the consumer.
+
+### Root WHERE
+
+`where` applies to every list, detail, update, and delete through the projection. Rows that don't match are invisible — detail returns `404`, updates/deletes on out-of-scope rows also return `404`.
+
+```typescript
+const activeCustomer = defineProjection(customerBO, {
+  name: 'activeCustomer',
+  actions: { read: true, update: true },
+  where: { status: 'ACTIVE' },
+})
+```
+
+### Registering the projection with Fastify
+
+```typescript
+import { registerProjection } from '@pgbo/fastify'
+
+registerProjection(app, db, {
+  projection: areaPublic,
+  view: areaView,
+  extractContext: req => ({ app, db, locale: 'en' }),
+})
+
+registerProjection(app, db, {
+  projection: areaAdmin,
+  view: areaView,
+  prefix: '/api/admin/areas',
+  extractContext: /* ... */,
+})
+```
+
+Multiple projections over the same BO coexist — you can surface a read-only public API, a CRUD admin API, and a reporting projection side-by-side without duplicating the BO.
+
+### Validation
+
+`defineProjection` throws at definition time if:
+- A whitelisted action doesn't exist on the underlying BO
+- A listed column doesn't exist on the BO's root table/view
+
+Fail-fast prevents broken projections from shipping.

--- a/packages/pgbo-fastify/README.md
+++ b/packages/pgbo-fastify/README.md
@@ -1,6 +1,6 @@
 # @pgbo/fastify
 
-Fastify route factory for [`@pgbo/core`](https://www.npmjs.com/package/@pgbo/core) Business Objects. Registers CRUD endpoints, metadata, value helps, and paginated list routes with search/filter/sort built in.
+Fastify route factory for [`@pgbo/core`](https://www.npmjs.com/package/@pgbo/core) Business Objects. Routes are registered via **projections** — explicit whitelists that declare which actions, columns, and rows are reachable over HTTP.
 
 ## Install
 
@@ -13,14 +13,20 @@ npm install @pgbo/core @pgbo/fastify fastify
 ```typescript
 import Fastify from 'fastify'
 import { createDatabase } from '@pgbo/core'
-import { registerBoRoutes } from '@pgbo/fastify'
+import { defineProjection } from '@pgbo/core/bo'
+import { registerProjection } from '@pgbo/fastify'
 import { warehouseBO, warehouseView } from './schema.js'
+
+const warehousePublic = defineProjection(warehouseBO, {
+  name: 'warehouse',
+  actions: { read: true, create: true, update: true, delete: true },
+})
 
 const app = Fastify()
 const db = createDatabase({ connectionString: 'postgresql://localhost/mydb' })
 
-registerBoRoutes(app, db, {
-  bo: warehouseBO,
+registerProjection(app, db, {
+  projection: warehousePublic,
   view: warehouseView,
   extractContext: (req) => ({
     app,
@@ -36,18 +42,49 @@ await app.listen({ port: 3000 })
 
 ## Features
 
-- **GET** `{prefix}` — paginated list with search, filter, sort (multi-column ORDER BY supported)
+- **Explicit action whitelist** — accidental exposure is impossible. An action is reachable only when named `true` in the projection.
+- **Column narrowing** — responses and metadata return only projected columns
+- **Root WHERE** — out-of-scope rows 404 even if they exist in the database
+- **GET** `{prefix}` — paginated list with search, filter, multi-column sort
 - **GET** `{prefix}/:param` — single item with composition enrichment
-- **GET** `/bo/{name}` — metadata with `labelKey` fallback
-- **GET** `/bo/{name}/valueHelp/{vhName}` — dropdown data sources
-- **POST / PUT / DELETE** — CRUD with action-based gating, afterWrite hooks, and global-record write protection
-- **POST** `/bo/{name}/{actionName}` — auto-registered for every custom BO action
-- **File / binary responses** — return a `FileResponse` from an action handler to send PDF/XLSX/CSV/etc. with proper `Content-Type` and `Content-Disposition`
-- **`registerViewRoute`** — read-only paginated view endpoint
+- **GET** `/bo/{projection}` — narrowed metadata with `labelKey` fallback
+- **GET** `/bo/{projection}/valueHelp/{vhName}` — dropdown data sources
+- **POST / PUT / DELETE** — when whitelisted; `afterWrite` hooks; global-record write protection
+- **POST** `/bo/{projection}/{actionName}` — one route per whitelisted custom action
+- **File / binary responses** — return a `FileResponse` from an action handler
+- **`registerViewRoute`** — read-only paginated view endpoint (no projection)
+
+## Projections
+
+One BO, many tailored surfaces:
+
+```typescript
+import { defineProjection } from '@pgbo/core/bo'
+
+// Public — read-only, only safe fields visible
+const areaPublic = defineProjection(areaBO, {
+  name: 'areaPublic',
+  actions: { read: true },
+  columns: ['id', 'slug', 'name'],
+})
+
+// Admin — full CRUD + one custom action; internalExport NOT whitelisted
+const areaAdmin = defineProjection(areaBO, {
+  name: 'areaAdmin',
+  actions: { read: true, create: true, update: true, delete: true, rebuildCache: true },
+})
+
+// Published-only subset
+const areaPublished = defineProjection(areaBO, {
+  name: 'areaPublished',
+  actions: { read: true, update: true },
+  where: { status: 'PUBLISHED' },
+})
+```
+
+All three can be registered on the same Fastify instance. The admin and public surfaces coexist without duplicating the BO definition.
 
 ## Custom actions and file responses
-
-Every non-standard action on a BO is auto-exposed as `POST /bo/{boName}/{actionName}`:
 
 ```typescript
 import type { FileResponse } from '@pgbo/fastify'
@@ -68,13 +105,17 @@ export const documentBO = defineBO(documentTable, {
     },
   },
 })
+
+const documentProjection = defineProjection(documentBO, {
+  name: 'document',
+  actions: { read: true, create: true, reverse: true, pdf: true },
+  // 'update' and 'delete' NOT whitelisted — even though they exist on the BO
+})
 ```
 
-- Custom actions that return a value → JSON body, status 200
-- Custom actions that return `undefined` / `null` → status 204 (no body)
-- Custom actions that return `FileResponse` → binary body with `Content-Type` + `Content-Disposition` headers
-
-Standard `create` / `update` / `delete` keep their existing REST routes and are NOT also exposed under `/{actionName}` — no duplication.
+- Custom action returning a value → JSON body, status 200
+- Custom action returning `undefined` / `null` → status 204 (no body)
+- Custom action returning `FileResponse` → binary body with `Content-Type` + `Content-Disposition`
 
 Full documentation: **<https://tim-riep.github.io/pgbo/>**. Source and issues: <https://github.com/tim-riep/pgbo>.
 

--- a/packages/pgbo-fastify/src/index.ts
+++ b/packages/pgbo-fastify/src/index.ts
@@ -1,4 +1,4 @@
-export { registerBoRoutes, registerViewRoute } from './routes.js'
+export { registerProjection, registerViewRoute } from './routes.js'
 export { paginateView, buildTenantWhere } from './helpers.js'
-export type { BoRouteConfig, ViewRouteConfig, RouteContext, FileResponse } from './types.js'
+export type { ProjectionRouteConfig, ViewRouteConfig, RouteContext, FileResponse } from './types.js'
 export type { PaginateOptions } from './helpers.js'

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -1,12 +1,17 @@
 // BO and View route factories for Fastify
+//
+// HTTP surface is defined by `registerProjection` — projections are the only
+// thing wired to HTTP (issue #15). Base BOs remain importable for internal
+// use (custom action handlers, CLI, seeds) but cannot be exposed directly.
 
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import type { Database } from '@pgbo/core'
 import type { ViewDef } from '@pgbo/core/schema'
+import type { WhereConditions } from '@pgbo/core/query'
 import { parseListParams } from '@pgbo/core/query'
 import { boMeta, viewMeta, type BOMeta, type FieldMeta } from '@pgbo/core/metadata'
-import { enrichCompositions } from '@pgbo/core/bo'
-import type { BoRouteConfig, ViewRouteConfig, FileResponse } from './types.js'
+import { enrichCompositions, projectRow, projectionExposes, type ProjectionDef } from '@pgbo/core/bo'
+import type { ProjectionRouteConfig, ViewRouteConfig, FileResponse } from './types.js'
 import { paginateView, buildTenantWhere } from './helpers.js'
 
 interface TypedBoMethods {
@@ -46,32 +51,40 @@ async function sendActionResult(reply: FastifyReply, result: unknown): Promise<v
   await reply.send(result)
 }
 
-function resolveView(config: BoRouteConfig): ViewDef {
+function resolveView(config: ProjectionRouteConfig): ViewDef {
   if (config.view) return config.view
-  const root = config.bo.root
+  const root = config.projection.bo.root
   if ('source' in root) return root
-  throw new Error(`BO "${config.bo.name}" root is a TableDef — pass an explicit view in BoRouteConfig`)
+  throw new Error(`BO "${config.projection.bo.name}" root is a TableDef — pass an explicit view in ProjectionRouteConfig`)
 }
 
 type PublicFieldMeta = Omit<FieldMeta, 'label'> & { readonly labelKey: string }
 type PublicBoMeta = Omit<BOMeta, 'fields'> & { readonly fields: readonly PublicFieldMeta[] }
 
-/** Transform boMeta output: label → labelKey with `${boName}.${key}` fallback, hidden → inList/inForm: false */
-function transformBoMeta(meta: BOMeta): PublicBoMeta {
-  const fields = meta.fields.map((f): PublicFieldMeta => ({
-    key: f.key,
-    kind: f.kind,
-    labelKey: f.label ?? `${meta.name}.${f.key}`,
-    hidden: f.hidden,
-    immutable: f.immutable,
-    searchable: f.searchable,
-    filterable: f.filterable,
-    inList: f.hidden ? false : f.inList,
-    inForm: f.hidden ? false : f.inForm,
-    required: f.required,
-    quick: f.quick,
-  }))
-  return { ...meta, fields }
+/**
+ * Transform boMeta output:
+ * - label → labelKey with `${projectionName}.${key}` fallback
+ * - hidden → inList/inForm: false
+ * - restricts field list to the projection's column allowlist if set
+ */
+function transformProjectionMeta(projection: ProjectionDef, meta: BOMeta): PublicBoMeta {
+  const allowed = projection.columns ? new Set(projection.columns) : undefined
+  const fields = meta.fields
+    .filter(f => !allowed || allowed.has(f.key))
+    .map((f): PublicFieldMeta => ({
+      key: f.key,
+      kind: f.kind,
+      labelKey: f.label ?? `${projection.name}.${f.key}`,
+      hidden: f.hidden,
+      immutable: f.immutable,
+      searchable: f.searchable,
+      filterable: f.filterable,
+      inList: f.hidden ? false : f.inList,
+      inForm: f.hidden ? false : f.inForm,
+      required: f.required,
+      quick: f.quick,
+    }))
+  return { ...meta, name: projection.name, fields }
 }
 
 /** Attach `global: true` to rows where tenantColumn is null (for includeGlobal routes) */
@@ -86,36 +99,56 @@ function extractParam(req: FastifyRequest): string {
   return value
 }
 
+/** Merge the projection's root WHERE with any other conditions. Returns undefined if both are empty. */
+function mergeWhere(a: WhereConditions | undefined, b: Record<string, unknown> | undefined): WhereConditions | undefined {
+  if (!a && !b) return undefined
+  if (!a) return b as WhereConditions
+  if (!b) return a
+  return { ...a, ...b } as WhereConditions
+}
+
 /**
- * Register CRUD + metadata routes for a Business Object.
+ * Register HTTP routes for a projection. This is the only way to wire a BO to HTTP.
  *
- * Routes:
- * - GET  {prefix}           — paginated list
- * - GET  {prefix}/:param    — single item by paramField
- * - GET  /bo/{name}         — BO metadata (fields, compositions, valueHelps)
- * - POST {prefix}           — create
- * - PUT  {prefix}/:param    — update
- * - DELETE {prefix}/:param  — delete
+ * Only actions whitelisted in `projection.actions` produce routes:
+ * - `read: true`   — GET {prefix} (list) + GET {prefix}/:param (detail) + GET /bo/{name} (metadata)
+ * - `create: true` — POST {prefix}
+ * - `update: true` — PUT {prefix}/:param
+ * - `delete: true` — DELETE {prefix}/:param
+ * - `<custom>: true` — POST /bo/{name}/{custom}
+ *
+ * Actions not listed are NOT registered. Accidental exposure is impossible.
  */
-export function registerBoRoutes(app: FastifyInstance, db: Database, config: BoRouteConfig): void {
-  const bo = config.bo
+export function registerProjection(app: FastifyInstance, db: Database, config: ProjectionRouteConfig): void {
+  const projection = config.projection
+  const bo = projection.bo
   const boMethods = bo as unknown as TypedBoMethods
   const viewDef = resolveView(config)
-  const prefix = config.prefix ?? bo.routePrefix ?? `/bo/${bo.name}`
+  const prefix = config.prefix ?? bo.routePrefix ?? `/bo/${projection.name}`
   const paramField = bo.paramField
   const tenantCol = config.tenantColumn ?? 'tenantId'
   const includeGlobal = config.includeGlobal ?? false
   const valueHelps = config.valueHelps ?? bo.valueHelps
 
-  // Fetch a single row by paramField — used by detail + write-protection
+  const readExposed = projectionExposes(projection, 'read')
+
+  // Apply projection column narrowing to a row (or no-op when no columns are set)
+  function narrow(row: Record<string, unknown>): Record<string, unknown> {
+    return projection.columns ? projectRow(projection, row) : { ...row }
+  }
+  function narrowAll(rows: Record<string, unknown>[]): Record<string, unknown>[] {
+    return projection.columns ? rows.map(r => projectRow(projection, r)) : rows
+  }
+
+  // Fetch a single row by paramField — used by detail + write-protection.
+  // Applies the projection's root WHERE so "invisible" rows 404 even if they exist.
   async function fetchByParam(paramValue: string, userId?: string): Promise<Record<string, unknown> | undefined> {
-    let q = db.from(viewDef).where({ [paramField]: paramValue })
+    let q = db.from(viewDef).where(mergeWhere({ [paramField]: paramValue } as WhereConditions, projection.where) ?? { [paramField]: paramValue } as WhereConditions)
     if (userId) q = q.as(userId)
     const rows = await q.execute()
     return rows[0] as Record<string, unknown> | undefined
   }
 
-  // Enforce global-record write protection (403 when tenantCol is null and includeGlobal is set)
   function assertNotGlobal(row: Record<string, unknown>, reply: FastifyReply): boolean {
     if (!includeGlobal) return true
     if (row[tenantCol] === null || row[tenantCol] === undefined) {
@@ -125,150 +158,143 @@ export function registerBoRoutes(app: FastifyInstance, db: Database, config: BoR
     return true
   }
 
-  // GET list
-  app.get(prefix, async (req: FastifyRequest) => {
-    const ctx = await config.extractContext(req)
-    const params = parseListParams(req.query as Record<string, unknown>)
+  // Read routes: GET list + GET detail + GET metadata
+  if (readExposed) {
+    app.get(prefix, async (req: FastifyRequest) => {
+      const ctx = await config.extractContext(req)
+      const params = parseListParams(req.query as Record<string, unknown>)
 
-    const baseWhere = ctx.tenantId
-      ? buildTenantWhere(ctx.tenantId, tenantCol, includeGlobal)
-      : undefined
+      const tenantWhere = ctx.tenantId
+        ? buildTenantWhere(ctx.tenantId, tenantCol, includeGlobal)
+        : undefined
+      const baseWhere = mergeWhere(tenantWhere, projection.where)
 
-    const result = await paginateView({
-      db, view: viewDef, params, baseWhere, userId: ctx.userId,
+      const result = await paginateView({
+        db, view: viewDef, params, baseWhere, userId: ctx.userId,
+      })
+
+      let items = result.items as Record<string, unknown>[]
+      if (Object.keys(bo.compositions).length > 0) {
+        items = await enrichCompositions(db, bo, items)
+      }
+      if (bo.transformItems) {
+        items = await bo.transformItems(items, ctx.locale, db)
+      }
+      if (includeGlobal) items = attachGlobalFlag(items, tenantCol)
+      items = narrowAll(items)
+
+      return { items, total: result.total, page: result.page, limit: result.limit }
     })
 
-    // Enrich
-    let items = result.items as Record<string, unknown>[]
-    if (Object.keys(bo.compositions).length > 0) {
-      items = await enrichCompositions(db, bo, items)
-    }
-    if (bo.transformItems) {
-      items = await bo.transformItems(items, ctx.locale, db)
-    }
-    if (includeGlobal) {
-      items = attachGlobalFlag(items, tenantCol)
-    }
+    app.get(`${prefix}/:param`, async (req: FastifyRequest, reply: FastifyReply) => {
+      const ctx = await config.extractContext(req)
+      const paramValue = extractParam(req)
 
-    return { items, total: result.total, page: result.page, limit: result.limit }
-  })
+      const row = await fetchByParam(paramValue, ctx.userId)
+      if (!row) {
+        reply.code(404)
+        return { error: 'Not found' }
+      }
 
-  // GET single item
-  app.get(`${prefix}/:param`, async (req: FastifyRequest, reply: FastifyReply) => {
-    const ctx = await config.extractContext(req)
-    const paramValue = extractParam(req)
+      let items: Record<string, unknown>[] = [row]
+      if (Object.keys(bo.compositions).length > 0) {
+        items = await enrichCompositions(db, bo, items)
+      }
+      if (bo.transformItems) {
+        items = await bo.transformItems(items, ctx.locale, db)
+      }
+      if (includeGlobal) items = attachGlobalFlag(items, tenantCol)
+      items = narrowAll(items)
 
-    const row = await fetchByParam(paramValue, ctx.userId)
-    if (!row) {
-      reply.code(404)
-      return { error: 'Not found' }
-    }
+      return items[0]
+    })
 
-    let items: Record<string, unknown>[] = [row]
-    if (Object.keys(bo.compositions).length > 0) {
-      items = await enrichCompositions(db, bo, items)
-    }
-    if (bo.transformItems) {
-      items = await bo.transformItems(items, ctx.locale, db)
-    }
-    if (includeGlobal) {
-      items = attachGlobalFlag(items, tenantCol)
-    }
+    // Metadata — reflects the narrowed surface
+    app.get(`/bo/${projection.name}`, () => transformProjectionMeta(projection, boMeta(bo)))
 
-    return items[0]
-  })
+    // Value help endpoints
+    if (Object.keys(valueHelps).length > 0) {
+      for (const [vhName, vh] of Object.entries(valueHelps)) {
+        app.get(`/bo/${projection.name}/valueHelp/${vhName}`, async (req: FastifyRequest) => {
+          const ctx = await config.extractContext(req)
+          const params = parseListParams(req.query as Record<string, unknown>)
 
-  // GET metadata
-  app.get(`/bo/${bo.name}`, () => transformBoMeta(boMeta(bo)))
+          if ('source' in vh && typeof vh.source === 'object') {
+            const result = await paginateView({
+              db, view: vh as ViewDef, params, userId: ctx.userId,
+            })
+            return { items: result.items, total: result.total, page: result.page, limit: result.limit }
+          }
 
-  // Value help endpoints
-  if (Object.keys(valueHelps).length > 0) {
-    for (const [vhName, vh] of Object.entries(valueHelps)) {
-      app.get(`/bo/${bo.name}/valueHelp/${vhName}`, async (req: FastifyRequest) => {
-        const ctx = await config.extractContext(req)
-        const params = parseListParams(req.query as Record<string, unknown>)
-
-        // ViewDef has `source` as a TableDef; ValueHelpViewDef uses keyField/displayField
-        if ('source' in vh && typeof vh.source === 'object') {
-          const result = await paginateView({
-            db, view: vh as ViewDef, params, userId: ctx.userId,
-          })
-          return { items: result.items, total: result.total, page: result.page, limit: result.limit }
-        }
-
-        // ValueHelpViewDef — plain SELECT of key, display
-        const offset = (params.page - 1) * params.limit
-        const [items, countRows] = await Promise.all([
-          db.query(`SELECT * FROM ${vh.name} LIMIT ${params.limit} OFFSET ${offset}`),
-          db.query<{ count: string }>(`SELECT COUNT(*) AS count FROM ${vh.name}`),
-        ])
-        const total = Number(countRows[0]?.count ?? 0)
-        return { items, total, page: params.page, limit: params.limit }
-      })
+          const offset = (params.page - 1) * params.limit
+          const [items, countRows] = await Promise.all([
+            db.query(`SELECT * FROM ${vh.name} LIMIT ${params.limit} OFFSET ${offset}`),
+            db.query<{ count: string }>(`SELECT COUNT(*) AS count FROM ${vh.name}`),
+          ])
+          const total = Number(countRows[0]?.count ?? 0)
+          return { items, total, page: params.page, limit: params.limit }
+        })
+      }
     }
   }
 
   // POST create
-  if (bo.actions.create) {
+  if (projectionExposes(projection, 'create') && bo.actions.create) {
     app.post(prefix, async (req: FastifyRequest, reply: FastifyReply) => {
       const ctx = await config.extractContext(req)
       const data = req.body as Record<string, unknown>
-      const result = await boMethods.create(db, ctx, data)
+      const result = await boMethods.create(db, ctx, data) as Record<string, unknown>
       if (config.afterWrite) await config.afterWrite(ctx, 'create')
       reply.code(201)
-      return result
+      return narrow(result)
     })
   }
 
   // PUT update
-  if (bo.actions.update) {
+  if (projectionExposes(projection, 'update') && bo.actions.update) {
     app.put(`${prefix}/:param`, async (req: FastifyRequest, reply: FastifyReply) => {
       const ctx = await config.extractContext(req)
       const paramValue = extractParam(req)
 
-      if (includeGlobal) {
-        const existing = await fetchByParam(paramValue, ctx.userId)
-        if (!existing) {
-          reply.code(404)
-          return { error: 'Not found' }
-        }
-        if (!assertNotGlobal(existing, reply)) return { error: 'Global records are read-only' }
+      // Always resolve the existing row through the projection — out-of-scope records 404
+      const existing = await fetchByParam(paramValue, ctx.userId)
+      if (!existing) {
+        reply.code(404)
+        return { error: 'Not found' }
       }
+      if (includeGlobal && !assertNotGlobal(existing, reply)) return { error: 'Global records are read-only' }
 
       const data = { ...(req.body as Record<string, unknown>), [paramField]: paramValue }
-      const result = await boMethods.update(db, ctx, data)
+      const result = await boMethods.update(db, ctx, data) as Record<string, unknown>
       if (config.afterWrite) await config.afterWrite(ctx, 'update')
-      return result
+      return narrow(result)
     })
   }
 
   // DELETE
-  if (bo.actions.delete) {
+  if (projectionExposes(projection, 'delete') && bo.actions.delete) {
     app.delete(`${prefix}/:param`, async (req: FastifyRequest, reply: FastifyReply) => {
       const ctx = await config.extractContext(req)
       const paramValue = extractParam(req)
 
-      if (includeGlobal) {
-        const existing = await fetchByParam(paramValue, ctx.userId)
-        if (!existing) {
-          reply.code(404)
-          return { error: 'Not found' }
-        }
-        if (!assertNotGlobal(existing, reply)) return { error: 'Global records are read-only' }
+      const existing = await fetchByParam(paramValue, ctx.userId)
+      if (!existing) {
+        reply.code(404)
+        return { error: 'Not found' }
       }
+      if (includeGlobal && !assertNotGlobal(existing, reply)) return { error: 'Global records are read-only' }
 
-      const result = await boMethods.delete(db, ctx, { [paramField]: paramValue })
+      const result = await boMethods.delete(db, ctx, { [paramField]: paramValue }) as Record<string, unknown>
       if (config.afterWrite) await config.afterWrite(ctx, 'delete')
-      return result
+      return narrow(result)
     })
   }
 
-  // Custom actions — any action that isn't create/update/delete gets exposed as
-  // POST /bo/{name}/{actionName}. Handler return values are JSON-serialized, or
-  // sent as binary when the handler returns a FileResponse (see types.ts).
+  // Custom actions — only those explicitly whitelisted
   for (const actionName of Object.keys(bo.actions)) {
     if (STANDARD_ACTIONS.has(actionName)) continue
-    app.post(`/bo/${bo.name}/${actionName}`, async (req: FastifyRequest, reply: FastifyReply) => {
+    if (!projectionExposes(projection, actionName)) continue
+    app.post(`/bo/${projection.name}/${actionName}`, async (req: FastifyRequest, reply: FastifyReply) => {
       const ctx = await config.extractContext(req)
       const data = (req.body as Record<string, unknown> | undefined) ?? {}
       const result = await boMethods.execute(db, actionName, ctx, data)

--- a/packages/pgbo-fastify/src/types.ts
+++ b/packages/pgbo-fastify/src/types.ts
@@ -3,7 +3,7 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type { Database } from '@pgbo/core'
 import type { ViewDef, ValueHelpViewDef } from '@pgbo/core/schema'
-import type { BusinessObjectDef } from '@pgbo/core/bo'
+import type { ProjectionDef } from '@pgbo/core/bo'
 
 export interface RouteContext {
   readonly app: FastifyInstance
@@ -13,12 +13,12 @@ export interface RouteContext {
   readonly locale: string
 }
 
-export interface BoRouteConfig {
-  /** The BO definition */
-  readonly bo: BusinessObjectDef
-  /** The view to query (defaults to bo.root if it's a ViewDef) */
+export interface ProjectionRouteConfig {
+  /** The projection — defines the HTTP surface (whitelist, columns, WHERE). */
+  readonly projection: ProjectionDef
+  /** The view to query (defaults to projection.bo.root if it's a ViewDef) */
   readonly view?: ViewDef
-  /** Route prefix override (defaults to bo.routePrefix or `/bo/${bo.name}`) */
+  /** Route prefix override (defaults to projection.bo.routePrefix or `/bo/${projection.name}`) */
   readonly prefix?: string
   /** Include global (tenant-less) rows alongside tenant-scoped rows */
   readonly includeGlobal?: boolean
@@ -28,7 +28,10 @@ export interface BoRouteConfig {
   readonly extractContext: (req: FastifyRequest) => RouteContext | Promise<RouteContext>
   /** Optional hook called after a successful create/update/delete — useful for cache invalidation */
   readonly afterWrite?: (ctx: RouteContext, action: 'create' | 'update' | 'delete') => void | Promise<void>
-  /** Value help views keyed by name. Registers GET /bo/{name}/valueHelp/{vhName}. Defaults to bo.valueHelps */
+  /**
+   * Value help views keyed by name. Registers `GET /bo/{projection.name}/valueHelp/{vhName}`.
+   * Defaults to `projection.bo.valueHelps`.
+   */
   readonly valueHelps?: Readonly<Record<string, ViewDef | ValueHelpViewDef>>
 }
 

--- a/packages/pgbo-fastify/tests/custom-actions.test.ts
+++ b/packages/pgbo-fastify/tests/custom-actions.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import Fastify from 'fastify'
 import { table, view, text, integer } from '@pgbo/core/schema'
-import { defineBO } from '@pgbo/core/bo'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
 import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
-import { registerBoRoutes, type FileResponse } from '../src/index.js'
+import { registerProjection, type FileResponse } from '../src/index.js'
 
 const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
 
@@ -58,6 +58,14 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
     },
   })
 
+  const roleProjection = defineProjection(roleBO, {
+    name: 'role',
+    actions: {
+      read: true, create: true, update: true, delete: true,
+      availableFragments: true, objectRefValues: true, pdf: true, markRead: true,
+    },
+  })
+
   beforeAll(async () => {
     testDb = await createTestDatabase({
       connectionString,
@@ -75,8 +83,8 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
 
   function mkApp(): ReturnType<typeof Fastify> {
     const app = Fastify()
-    registerBoRoutes(app, testDb.db, {
-      bo: roleBO,
+    registerProjection(app, testDb.db, {
+      projection: roleProjection,
       view: roleView,
       extractContext: () => ({ app, db: testDb.db, locale: 'en', userId: 'user-123' }),
     })
@@ -151,9 +159,10 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
         },
       },
     })
+    const testProjection = defineProjection(testBO, { name: 'role', actions: { download: true } })
     const app = Fastify()
-    registerBoRoutes(app, testDb.db, {
-      bo: testBO,
+    registerProjection(app, testDb.db, {
+      projection: testProjection,
       view: roleView,
       extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
     })
@@ -180,9 +189,10 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
         },
       },
     })
+    const throwingProjection = defineProjection(throwingBO, { name: 'role', actions: { broken: true } })
     const app = Fastify()
-    registerBoRoutes(app, testDb.db, {
-      bo: throwingBO,
+    registerProjection(app, testDb.db, {
+      projection: throwingProjection,
       view: roleView,
       extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
     })

--- a/packages/pgbo-fastify/tests/features.test.ts
+++ b/packages/pgbo-fastify/tests/features.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import Fastify from 'fastify'
 import { table, view, valueHelpView, text, integer, col } from '@pgbo/core/schema'
-import { defineBO } from '@pgbo/core/bo'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
 import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
-import { registerBoRoutes } from '../src/index.js'
+import { registerProjection } from '../src/index.js'
 
 const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
 
@@ -34,6 +34,11 @@ const warehouseBO = defineBO(warehouseTable, {
   valueHelps: { warehouse: warehouseVH },
 })
 
+const warehouseProjection = defineProjection(warehouseBO, {
+  name: 'warehouse',
+  actions: { read: true, create: true, update: true, delete: true },
+})
+
 describe('pgbo-fastify — issue 026 features', () => {
   let testDb: TestDatabase
 
@@ -60,8 +65,8 @@ describe('pgbo-fastify — issue 026 features', () => {
   describe('1. ILIKE search via view annotations', () => {
     it('applies ILIKE on searchable columns when search param is present', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -75,8 +80,8 @@ describe('pgbo-fastify — issue 026 features', () => {
 
     it('searches across multiple searchable columns (OR)', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -92,8 +97,8 @@ describe('pgbo-fastify — issue 026 features', () => {
   describe('2. Metadata labelKey transform', () => {
     it('returns labelKey with fallback to `${boName}.${key}`', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -111,8 +116,8 @@ describe('pgbo-fastify — issue 026 features', () => {
   describe('3. Value help endpoints', () => {
     it('registers GET /bo/{name}/valueHelp/{vhName}', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -130,8 +135,8 @@ describe('pgbo-fastify — issue 026 features', () => {
     it('calls afterWrite after successful create/update/delete', async () => {
       const calls: Array<{ action: string }> = []
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
         afterWrite: (_ctx, action) => { calls.push({ action }) },
@@ -155,8 +160,8 @@ describe('pgbo-fastify — issue 026 features', () => {
   describe('5 + 6. Global flag + write protection', () => {
     it('adds global: true for tenant-less rows when includeGlobal', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         includeGlobal: true,
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),
@@ -173,8 +178,8 @@ describe('pgbo-fastify — issue 026 features', () => {
 
     it('does NOT add global flag when includeGlobal is not set', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -187,8 +192,8 @@ describe('pgbo-fastify — issue 026 features', () => {
 
     it('returns 403 on PUT for global record when includeGlobal', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         includeGlobal: true,
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),
@@ -204,8 +209,8 @@ describe('pgbo-fastify — issue 026 features', () => {
 
     it('returns 403 on DELETE for global record when includeGlobal', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         includeGlobal: true,
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),
@@ -220,8 +225,8 @@ describe('pgbo-fastify — issue 026 features', () => {
       await testDb.raw("INSERT INTO warehouse (id, slug, name, tenant_id) VALUES (50, 'temp-tenant', 'Temp', 't1')")
 
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         includeGlobal: true,
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),

--- a/packages/pgbo-fastify/tests/projections.test.ts
+++ b/packages/pgbo-fastify/tests/projections.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify from 'fastify'
+import { table, view, text, integer } from '@pgbo/core/schema'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
+import { registerProjection } from '../src/index.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const areaTable = table('area', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+    name: text().notNull(),
+    internalNote: text(),  // sensitive — should be hidden on public projection
+  },
+  primaryKey: ['id'],
+})
+
+const areaView = view('area_view').from(areaTable)
+
+describe('Projections as HTTP surface (issue #15)', () => {
+  let testDb: TestDatabase
+
+  const areaBO = defineBO(areaTable, {
+    paramField: 'id',
+    actions: {
+      create: {},
+      update: {},
+      delete: {},
+      rebuildCache: { handler: () => ({ ok: true }) },
+      internalExport: { handler: () => ({ exported: 'secret' }) },
+    },
+  })
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [areaTable],
+      seed: [
+        'CREATE OR REPLACE VIEW area_view AS SELECT * FROM area',
+        "INSERT INTO area (id, slug, name, internal_note) VALUES (1, 'nav', 'Navigation', 'keep quiet')",
+        "INSERT INTO area (id, slug, name, internal_note) VALUES (2, 'admin', 'Admin', 'top secret')",
+        "INSERT INTO area (id, slug, name, internal_note) VALUES (3, 'draft', 'Draft', null)",
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  describe('action whitelist enforcement', () => {
+    const areaPublic = defineProjection(areaBO, {
+      name: 'areaPublic',
+      actions: { read: true },  // ONLY read
+    })
+
+    function mkApp(): ReturnType<typeof Fastify> {
+      const app = Fastify()
+      registerProjection(app, testDb.db, {
+        projection: areaPublic,
+        view: areaView,
+        prefix: '/api/public/areas',
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+      return app
+    }
+
+    it('read-only projection exposes GET list', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/api/public/areas' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json().items).toHaveLength(3)
+      await app.close()
+    })
+
+    it('read-only projection exposes GET detail', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/api/public/areas/1' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json().slug).toBe('nav')
+      await app.close()
+    })
+
+    it('read-only projection exposes GET metadata', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/bo/areaPublic' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json().name).toBe('areaPublic')
+      await app.close()
+    })
+
+    it('read-only projection does NOT expose POST create', async () => {
+      const app = mkApp()
+      const res = await app.inject({
+        method: 'POST', url: '/api/public/areas',
+        payload: { id: 99, slug: 'x', name: 'X' },
+      })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+
+    it('read-only projection does NOT expose PUT update', async () => {
+      const app = mkApp()
+      const res = await app.inject({
+        method: 'PUT', url: '/api/public/areas/1', payload: { name: 'Hijacked' },
+      })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+
+    it('read-only projection does NOT expose DELETE', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'DELETE', url: '/api/public/areas/1' })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+
+    it('read-only projection does NOT expose ANY custom action', async () => {
+      const app = mkApp()
+      const a = await app.inject({ method: 'POST', url: '/bo/areaPublic/rebuildCache' })
+      const b = await app.inject({ method: 'POST', url: '/bo/areaPublic/internalExport' })
+      expect(a.statusCode).toBe(404)
+      expect(b.statusCode).toBe(404)
+      await app.close()
+    })
+  })
+
+  describe('selectively exposed custom action', () => {
+    const areaAdmin = defineProjection(areaBO, {
+      name: 'areaAdmin',
+      actions: { read: true, create: true, update: true, delete: true, rebuildCache: true },
+      // internalExport NOT whitelisted
+    })
+
+    function mkApp(): ReturnType<typeof Fastify> {
+      const app = Fastify()
+      registerProjection(app, testDb.db, {
+        projection: areaAdmin,
+        view: areaView,
+        prefix: '/api/admin/areas',
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+      return app
+    }
+
+    it('whitelisted custom action is exposed', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'POST', url: '/bo/areaAdmin/rebuildCache' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual({ ok: true })
+      await app.close()
+    })
+
+    it('non-whitelisted custom action is hidden (404)', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'POST', url: '/bo/areaAdmin/internalExport' })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+
+    it('standard CRUD is exposed when whitelisted', async () => {
+      const app = mkApp()
+      const post = await app.inject({
+        method: 'POST', url: '/api/admin/areas',
+        payload: { id: 100, slug: 'new', name: 'New' },
+      })
+      expect(post.statusCode).toBe(201)
+
+      const del = await app.inject({ method: 'DELETE', url: '/api/admin/areas/100' })
+      expect(del.statusCode).toBe(200)
+      await app.close()
+    })
+  })
+
+  describe('column narrowing', () => {
+    const areaMobile = defineProjection(areaBO, {
+      name: 'areaMobile',
+      actions: { read: true },
+      columns: ['id', 'slug', 'name'],  // internalNote hidden
+    })
+
+    function mkApp(): ReturnType<typeof Fastify> {
+      const app = Fastify()
+      registerProjection(app, testDb.db, {
+        projection: areaMobile,
+        view: areaView,
+        prefix: '/api/mobile/areas',
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+      return app
+    }
+
+    it('list response omits non-projected columns', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/api/mobile/areas' })
+      const body = res.json()
+      expect(body.items[0]).toEqual({ id: 1, slug: 'nav', name: 'Navigation' })
+      expect(body.items[0].internalNote).toBeUndefined()
+      await app.close()
+    })
+
+    it('detail response omits non-projected columns', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/api/mobile/areas/1' })
+      const body = res.json()
+      expect(body).toEqual({ id: 1, slug: 'nav', name: 'Navigation' })
+      expect(body.internalNote).toBeUndefined()
+      await app.close()
+    })
+
+    it('metadata response omits non-projected fields', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/bo/areaMobile' })
+      const fieldKeys = res.json().fields.map((f: { key: string }) => f.key)
+      expect(fieldKeys).toEqual(['id', 'slug', 'name'])
+      expect(fieldKeys).not.toContain('internalNote')
+      await app.close()
+    })
+  })
+
+  describe('root WHERE', () => {
+    const publishedOnly = defineProjection(areaBO, {
+      name: 'areaPublished',
+      actions: { read: true, update: true, delete: true },
+      where: { slug: { in: ['nav', 'admin'] } },  // 'draft' invisible
+    })
+
+    function mkApp(): ReturnType<typeof Fastify> {
+      const app = Fastify()
+      registerProjection(app, testDb.db, {
+        projection: publishedOnly,
+        view: areaView,
+        prefix: '/api/pub/areas',
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+      return app
+    }
+
+    it('list filters by root WHERE', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/api/pub/areas' })
+      const slugs = res.json().items.map((i: { slug: string }) => i.slug).sort()
+      expect(slugs).toEqual(['admin', 'nav'])  // 'draft' filtered out
+      await app.close()
+    })
+
+    it('detail 404s for out-of-scope rows', async () => {
+      const app = mkApp()
+      // draft (id 3) exists but is invisible through this projection
+      const res = await app.inject({ method: 'GET', url: '/api/pub/areas/3' })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+
+    it('detail succeeds for in-scope rows', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'GET', url: '/api/pub/areas/1' })
+      expect(res.statusCode).toBe(200)
+      await app.close()
+    })
+
+    it('update on out-of-scope row 404s', async () => {
+      const app = mkApp()
+      const res = await app.inject({
+        method: 'PUT', url: '/api/pub/areas/3', payload: { name: 'Hijacked' },
+      })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+
+    it('delete on out-of-scope row 404s', async () => {
+      const app = mkApp()
+      const res = await app.inject({ method: 'DELETE', url: '/api/pub/areas/3' })
+      expect(res.statusCode).toBe(404)
+      await app.close()
+    })
+  })
+
+  describe('multi-projection isolation', () => {
+    it('two projections over the same BO coexist with different surfaces', async () => {
+      const areaRead = defineProjection(areaBO, {
+        name: 'areaRead', actions: { read: true },
+      })
+      const areaFull = defineProjection(areaBO, {
+        name: 'areaFull', actions: { read: true, create: true, update: true, delete: true, rebuildCache: true },
+      })
+
+      const app = Fastify()
+      registerProjection(app, testDb.db, {
+        projection: areaRead, view: areaView, prefix: '/public/areas',
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+      registerProjection(app, testDb.db, {
+        projection: areaFull, view: areaView, prefix: '/admin/areas',
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+
+      // Read available on both
+      expect((await app.inject({ method: 'GET', url: '/public/areas' })).statusCode).toBe(200)
+      expect((await app.inject({ method: 'GET', url: '/admin/areas' })).statusCode).toBe(200)
+
+      // Delete only on admin
+      expect((await app.inject({ method: 'DELETE', url: '/public/areas/1' })).statusCode).toBe(404)
+      // rebuildCache only on admin
+      expect((await app.inject({ method: 'POST', url: '/bo/areaRead/rebuildCache' })).statusCode).toBe(404)
+      expect((await app.inject({ method: 'POST', url: '/bo/areaFull/rebuildCache' })).statusCode).toBe(200)
+
+      await app.close()
+    })
+  })
+})

--- a/packages/pgbo-fastify/tests/routes.test.ts
+++ b/packages/pgbo-fastify/tests/routes.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import Fastify from 'fastify'
 import { table, text, integer, view } from '@pgbo/core/schema'
-import { defineBO } from '@pgbo/core/bo'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
 import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
-import { registerBoRoutes, registerViewRoute } from '../src/index.js'
+import { registerProjection, registerViewRoute } from '../src/index.js'
 
 const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
 
@@ -26,6 +26,11 @@ const warehouseBO = defineBO(warehouseTable, {
   orderBy: 'name',
 })
 
+const warehouseProjection = defineProjection(warehouseBO, {
+  name: 'warehouse',
+  actions: { read: true, create: true, update: true, delete: true },
+})
+
 describe('pgbo-fastify route factory', () => {
   let testDb: TestDatabase
 
@@ -46,11 +51,11 @@ describe('pgbo-fastify route factory', () => {
     await testDb.dispose()
   })
 
-  describe('registerBoRoutes', () => {
+  describe('registerProjection', () => {
     it('GET list returns paginated items', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -67,8 +72,8 @@ describe('pgbo-fastify route factory', () => {
 
     it('GET list respects ?limit and ?page', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -83,8 +88,8 @@ describe('pgbo-fastify route factory', () => {
 
     it('GET single item by paramField', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -99,8 +104,8 @@ describe('pgbo-fastify route factory', () => {
 
     it('GET single item 404 when not found', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -112,8 +117,8 @@ describe('pgbo-fastify route factory', () => {
 
     it('GET /bo/{name} returns metadata', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -128,8 +133,8 @@ describe('pgbo-fastify route factory', () => {
 
     it('POST creates a new item', async () => {
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
@@ -149,8 +154,8 @@ describe('pgbo-fastify route factory', () => {
     it('DELETE removes an item', async () => {
       await testDb.raw("INSERT INTO warehouse (id, slug, name) VALUES (99, 'temp', 'Temp')")
       const app = Fastify()
-      registerBoRoutes(app, testDb.db, {
-        bo: warehouseBO,
+      registerProjection(app, testDb.db, {
+        projection: warehouseProjection,
         view: warehouseView,
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -83,5 +83,6 @@ export function defineBO<
   return impl as unknown as TypedBusinessObject<C, ResolveParam<C, Cfg>>
 }
 
-export { type BusinessObjectDef, type BOConfig, type ActionDef, type ActionContext, type CompositionDef, type TypedBusinessObject, type VirtualFieldMeta } from './types.js'
+export { type BusinessObjectDef, type BOConfig, type ActionDef, type ActionContext, type CompositionDef, type TypedBusinessObject, type VirtualFieldMeta, type ProjectionDef, type ProjectionConfig } from './types.js'
 export { enrichCompositions } from './enrich.js'
+export { defineProjection, projectRow, projectionExposes } from './projection.js'

--- a/packages/pgbo/src/bo/projection.ts
+++ b/packages/pgbo/src/bo/projection.ts
@@ -1,0 +1,79 @@
+// Projections — issue #15
+//
+// A projection is the HTTP surface layered on top of a BO. The BO holds the
+// data model, schema, and write logic; the projection declares what is reachable
+// over HTTP: which actions are whitelisted, which columns are visible, and what
+// root-level WHERE applies to every query.
+//
+// Only projections are exposed via `registerProjection` in @pgbo/fastify.
+// Base BOs remain importable for internal use (custom action handlers, CLI,
+// seed scripts) but never directly wired to HTTP.
+
+import type { BusinessObjectDef, ProjectionDef, ProjectionConfig } from './types.js'
+
+/**
+ * Define an HTTP projection of a Business Object.
+ *
+ * @example
+ * ```ts
+ * const areaPublic = defineProjection(areaBO, {
+ *   name: 'areaPublic',
+ *   actions: { read: true },
+ *   columns: ['id', 'slug', 'name'],
+ *   where: { published: true },
+ * })
+ * ```
+ */
+export function defineProjection(bo: BusinessObjectDef, config: ProjectionConfig): ProjectionDef {
+  // Validate: every action in the whitelist must exist on the BO (or be 'read', which is implicit)
+  for (const [actionName, enabled] of Object.entries(config.actions)) {
+    if (!enabled) continue
+    if (actionName === 'read') continue  // GET list+detail are always available from the underlying BO
+    if (!bo.actions[actionName]) {
+      throw new Error(
+        `Projection "${config.name}" whitelists action "${actionName}" but the underlying BO "${bo.name}" has no such action. Remove it or add it to the BO first.`,
+      )
+    }
+  }
+
+  // Validate: every column in the projection must exist on the BO root (if root is a view or table)
+  if (config.columns) {
+    const root = bo.root
+    const available = 'columns' in root ? Object.keys(root.columns) : undefined
+    if (available) {
+      for (const col of config.columns) {
+        if (!available.includes(col)) {
+          throw new Error(
+            `Projection "${config.name}" references column "${col}" which does not exist on "${bo.name}". Available columns: ${available.join(', ')}`,
+          )
+        }
+      }
+    }
+  }
+
+  return {
+    name: config.name,
+    bo,
+    actions: { ...config.actions },
+    columns: config.columns,
+    where: config.where,
+  }
+}
+
+/** Narrow a row to only the projection's columns. Returns a new object. */
+export function projectRow(
+  projection: ProjectionDef,
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!projection.columns) return { ...row }
+  const result: Record<string, unknown> = {}
+  for (const col of projection.columns) {
+    if (col in row) result[col] = row[col]
+  }
+  return result
+}
+
+/** Whether this projection exposes the given action name. */
+export function projectionExposes(projection: ProjectionDef, actionName: string): boolean {
+  return projection.actions[actionName] === true
+}

--- a/packages/pgbo/src/bo/types.ts
+++ b/packages/pgbo/src/bo/types.ts
@@ -62,6 +62,32 @@ export interface BusinessObjectDef {
   readonly transformItems?: (rows: Record<string, unknown>[], locale: string, db: any) => Promise<Record<string, unknown>[]>
 }
 
+// --- Projection (HTTP surface definition, layered on top of a BO) ---
+
+export interface ProjectionDef {
+  /** Public name used for routes, metadata endpoint, and logs */
+  readonly name: string
+  /** The underlying BO — data model + write logic + schema */
+  readonly bo: BusinessObjectDef
+  /**
+   * Explicit action whitelist. Only keys set to `true` are reachable via HTTP.
+   * Standard keys: 'read' (GET list + detail), 'create', 'update', 'delete'.
+   * Any custom action key from the BO can also be listed.
+   */
+  readonly actions: Readonly<Record<string, boolean>>
+  /** Narrow the visible columns in responses and metadata. Undefined → all BO columns. */
+  readonly columns?: readonly string[]
+  /** Applied to every list / detail / update / delete query through this projection. */
+  readonly where?: Record<string, unknown>
+}
+
+export interface ProjectionConfig {
+  readonly name: string
+  readonly actions: Record<string, boolean>
+  readonly columns?: readonly string[]
+  readonly where?: Record<string, unknown>
+}
+
 export interface BOConfig<C extends Record<string, AnyColumnBuilder> = Record<string, AnyColumnBuilder>> {
   name?: string
   paramField?: string & keyof C

--- a/packages/pgbo/tests/bo/projection.test.ts
+++ b/packages/pgbo/tests/bo/projection.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { text, integer } from '../../src/schema/types.js'
+import { defineBO } from '../../src/bo/index.js'
+import { defineProjection, projectRow, projectionExposes } from '../../src/bo/projection.js'
+
+const areaTable = table('area', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+    name: text().notNull(),
+    internalNote: text(),
+  },
+  primaryKey: ['id'],
+})
+
+describe('defineProjection (issue #15)', () => {
+  const areaBO = defineBO(areaTable, {
+    paramField: 'id',
+    actions: {
+      create: {},
+      update: {},
+      delete: {},
+      rebuildCache: { handler: () => ({ ok: true }) },
+      internalExport: { handler: () => ({ secret: 42 }) },
+    },
+  })
+
+  it('stores config on the ProjectionDef', () => {
+    const p = defineProjection(areaBO, {
+      name: 'areaPublic',
+      actions: { read: true },
+      columns: ['id', 'slug', 'name'],
+      where: { slug: 'nav' },
+    })
+    expect(p.name).toBe('areaPublic')
+    expect(p.bo).toBe(areaBO)
+    expect(p.actions).toEqual({ read: true })
+    expect(p.columns).toEqual(['id', 'slug', 'name'])
+    expect(p.where).toEqual({ slug: 'nav' })
+  })
+
+  it('throws if a whitelisted action does not exist on the BO', () => {
+    expect(() =>
+      defineProjection(areaBO, {
+        name: 'bad',
+        actions: { nonexistent: true },
+      }),
+    ).toThrow(/whitelists action "nonexistent" but the underlying BO "area" has no such action/)
+  })
+
+  it('does NOT throw for the implicit "read" action', () => {
+    expect(() =>
+      defineProjection(areaBO, {
+        name: 'readonly',
+        actions: { read: true },
+      }),
+    ).not.toThrow()
+  })
+
+  it('throws when column does not exist on the root', () => {
+    expect(() =>
+      defineProjection(areaBO, {
+        name: 'bad',
+        actions: { read: true },
+        columns: ['id', 'nonexistent'],
+      }),
+    ).toThrow(/references column "nonexistent" which does not exist/)
+  })
+
+  it('actions set to false are NOT in the whitelist (projectionExposes returns false)', () => {
+    const p = defineProjection(areaBO, {
+      name: 'p',
+      actions: { read: true, create: false },
+    })
+    expect(projectionExposes(p, 'read')).toBe(true)
+    expect(projectionExposes(p, 'create')).toBe(false)
+    expect(projectionExposes(p, 'delete')).toBe(false)  // not mentioned
+  })
+
+  it('custom actions from the BO can be whitelisted', () => {
+    const p = defineProjection(areaBO, {
+      name: 'admin',
+      actions: { read: true, rebuildCache: true },
+    })
+    expect(projectionExposes(p, 'rebuildCache')).toBe(true)
+    expect(projectionExposes(p, 'internalExport')).toBe(false)  // not listed
+  })
+
+  describe('projectRow', () => {
+    const p = defineProjection(areaBO, {
+      name: 'p',
+      actions: { read: true },
+      columns: ['id', 'slug'],
+    })
+
+    it('returns only the projected columns', () => {
+      const narrowed = projectRow(p, { id: 1, slug: 'nav', name: 'Navigation', internalNote: 'hidden' })
+      expect(narrowed).toEqual({ id: 1, slug: 'nav' })
+    })
+
+    it('projection without columns returns a shallow clone', () => {
+      const pAll = defineProjection(areaBO, { name: 'pAll', actions: { read: true } })
+      const row = { id: 1, slug: 'nav', name: 'Navigation' }
+      const result = projectRow(pAll, row)
+      expect(result).toEqual(row)
+      expect(result).not.toBe(row)  // clone, not reference
+    })
+
+    it('silently drops columns that are not on the input row', () => {
+      const narrowed = projectRow(p, { id: 1 } as Record<string, unknown>)
+      expect(narrowed).toEqual({ id: 1 })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Introduces **projections** as a separate layer between BOs and HTTP. Base BOs stay internal; only projections are wired to Fastify. The scope for this PR is the MVP — follow-up PRs add filtered compositions/associations, locked context, and composability.

### Breaking change

**\`@pgbo/fastify\`**: \`registerBoRoutes\` is removed and replaced by \`registerProjection\`. Users must wrap each BO in a \`defineProjection(...)\` call that explicitly whitelists which actions and columns are reachable.

### Core (\`@pgbo/core\`)

- **\`defineProjection(bo, { name, actions, columns?, where? })\`** — declare an HTTP surface over a BO
- **Validation at definition time** — unknown action keys and non-existent columns throw with a descriptive message
- **\`projectRow\`** / **\`projectionExposes\`** helpers
- **\`ProjectionDef\`** / **\`ProjectionConfig\`** types exported from \`@pgbo/core/bo\`

### Fastify (\`@pgbo/fastify\`)

- **\`registerProjection\`** replaces \`registerBoRoutes\` — only whitelisted actions produce routes
- **Root WHERE** — \`projection.where\` applies to every list / detail / update / delete; out-of-scope rows 404 even if they exist
- **Column narrowing** — \`projection.columns\` narrows response bodies AND the metadata endpoint
- **Multi-projection** — two+ projections over the same BO coexist (public + admin side-by-side, no BO duplication)

## Migration

\`\`\`ts
// Before
registerBoRoutes(app, db, { bo: warehouseBO, view: warehouseView, extractContext })

// After — one-shot (reproduces current behaviour)
const warehouseAll = defineProjection(warehouseBO, {
  name: 'warehouse',
  actions: { read: true, create: true, update: true, delete: true },
})
registerProjection(app, db, { projection: warehouseAll, view: warehouseView, extractContext })

// Or split by audience
const warehousePublic = defineProjection(warehouseBO, {
  name: 'warehousePublic', actions: { read: true }, columns: ['id', 'slug', 'name'],
})
const warehouseAdmin = defineProjection(warehouseBO, {
  name: 'warehouseAdmin', actions: { read: true, create: true, update: true, delete: true },
})
\`\`\`

## Deferred (follow-up PRs)

- Filtered compositions/associations on projections (PR #16 vocabulary is available)
- Locked context values (\`lock: { locale: '\$locale' }\`)
- Projection-of-projection composability

## Test plan

- [x] \`tests/bo/projection.test.ts\` — 9 unit tests: defineProjection happy paths, action/column validation errors, projectRow narrowing, projectionExposes
- [x] \`packages/pgbo-fastify/tests/projections.test.ts\` — 19 integration tests covering:
  - Action whitelist — read-only projection rejects POST/PUT/DELETE/custom actions (all 404)
  - Selective custom action exposure (one whitelisted, one hidden)
  - Column narrowing in list / detail / metadata responses
  - Root WHERE — out-of-scope detail/update/delete 404, list filtered
  - Multi-projection isolation (public + admin side-by-side)
- [x] Existing \`routes.test.ts\` / \`features.test.ts\` / \`custom-actions.test.ts\` migrated to \`registerProjection\` — all pass (27 tests)
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm test\` — 404 total tests pass, zero eslint-disable comments
- [x] Changeset: \`@pgbo/core\` minor (additive), \`@pgbo/fastify\` major (breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)