### PR TITLE
fix(fastify)!: move metadata to /meta/{name} to avoid route collision (closes #24)

### DIFF
--- a/.changeset/fix-metadata-route-collision.md
+++ b/.changeset/fix-metadata-route-collision.md
@@ -1,0 +1,30 @@
+---
+"@pgbo/fastify": major
+---
+
+Fix metadata route collision when `routePrefix` is not set (closes #24).
+
+**Breaking change**: BO metadata moves from `GET /bo/{projection.name}` to `GET /meta/{projection.name}`.
+
+### Why
+
+With no explicit `routePrefix` on the BO or `prefix` in the route config, the list route defaulted to `/bo/{projection.name}` — the same path used for metadata. Fastify refused to boot:
+
+> FastifyError: Method 'GET' already declared for route '/bo/warehouseProduct'
+
+This meant every BO without a custom `routePrefix` broke the app at startup.
+
+### Fix
+
+Metadata now lives in a dedicated `/meta/{projection.name}` namespace, sidestepping any path collision with list or detail routes. Value help endpoints (`/bo/{projection.name}/valueHelp/{vh}`) and custom actions (`POST /bo/{projection.name}/{actionName}`) stay unchanged.
+
+### Migration
+
+Frontend clients that fetched BO metadata must update the URL:
+
+```diff
+- GET /bo/warehouse
++ GET /meta/warehouse
+```
+
+The response shape is unchanged.

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -209,8 +209,9 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
       return items[0]
     })
 
-    // Metadata — reflects the narrowed surface
-    app.get(`/bo/${projection.name}`, () => transformProjectionMeta(projection, boMeta(bo)))
+    // Metadata — reflects the narrowed surface. Lives in a separate `/meta/` namespace
+    // so it never collides with the list/detail route prefix (#24).
+    app.get(`/meta/${projection.name}`, () => transformProjectionMeta(projection, boMeta(bo)))
 
     // Value help endpoints
     if (Object.keys(valueHelps).length > 0) {

--- a/packages/pgbo-fastify/tests/features.test.ts
+++ b/packages/pgbo-fastify/tests/features.test.ts
@@ -103,7 +103,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/bo/warehouse' })
+      const res = await app.inject({ method: 'GET', url: '/meta/warehouse' })
       const body = res.json()
       const slug = body.fields.find((f: any) => f.key === 'slug')
       expect(slug).toBeDefined()

--- a/packages/pgbo-fastify/tests/projections.test.ts
+++ b/packages/pgbo-fastify/tests/projections.test.ts
@@ -85,7 +85,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('read-only projection exposes GET metadata', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/bo/areaPublic' })
+      const res = await app.inject({ method: 'GET', url: '/meta/areaPublic' })
       expect(res.statusCode).toBe(200)
       expect(res.json().name).toBe('areaPublic')
       await app.close()
@@ -212,7 +212,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('metadata response omits non-projected fields', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/bo/areaMobile' })
+      const res = await app.inject({ method: 'GET', url: '/meta/areaMobile' })
       const fieldKeys = res.json().fields.map((f: { key: string }) => f.key)
       expect(fieldKeys).toEqual(['id', 'slug', 'name'])
       expect(fieldKeys).not.toContain('internalNote')

--- a/packages/pgbo-fastify/tests/route-prefix-collision.test.ts
+++ b/packages/pgbo-fastify/tests/route-prefix-collision.test.ts
@@ -1,0 +1,107 @@
+// Regression test for issue #24:
+// When a BO/projection has no explicit routePrefix, registerProjection must not
+// crash Fastify at boot with "Method 'GET' already declared for route '/bo/X'".
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify from 'fastify'
+import { table, view, text, integer } from '@pgbo/core/schema'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
+import { registerProjection } from '../src/index.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const thingTable = table('thing', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+    name: text().notNull(),
+  },
+  primaryKey: ['id'],
+})
+
+const thingView = view('thing_view').from(thingTable)
+
+describe('issue #24 — default routePrefix does not collide with metadata route', () => {
+  let testDb: TestDatabase
+
+  // A BO WITHOUT routePrefix — the default fallback triggered the bug
+  const thingBO = defineBO(thingTable, {
+    paramField: 'id',
+    actions: { create: {}, update: {}, delete: {} },
+  })
+
+  const thingProjection = defineProjection(thingBO, {
+    name: 'thing',
+    actions: { read: true, create: true, update: true, delete: true },
+  })
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [thingTable],
+      seed: [
+        'CREATE OR REPLACE VIEW thing_view AS SELECT * FROM thing',
+        "INSERT INTO thing (id, slug, name) VALUES (1, 'alpha', 'Alpha')",
+        "INSERT INTO thing (id, slug, name) VALUES (2, 'beta', 'Beta')",
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  it('registers without Fastify complaining about duplicate routes', async () => {
+    const app = Fastify()
+    expect(() => {
+      registerProjection(app, testDb.db, {
+        projection: thingProjection,
+        view: thingView,
+        extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+      })
+    }).not.toThrow()
+    await app.ready()  // forces Fastify to finalize the router
+    await app.close()
+  })
+
+  it('list route still serves data', async () => {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: thingProjection,
+      view: thingView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+    const res = await app.inject({ method: 'GET', url: '/bo/thing' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().items).toHaveLength(2)
+    await app.close()
+  })
+
+  it('detail route still serves a single row', async () => {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: thingProjection,
+      view: thingView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+    const res = await app.inject({ method: 'GET', url: '/bo/thing/1' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().slug).toBe('alpha')
+    await app.close()
+  })
+
+  it('metadata is reachable at a distinct path that does not collide with list', async () => {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: thingProjection,
+      view: thingView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+    const res = await app.inject({ method: 'GET', url: '/meta/thing' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().name).toBe('thing')
+    expect(Array.isArray(res.json().fields)).toBe(true)
+    await app.close()
+  })
+})

--- a/packages/pgbo-fastify/tests/routes.test.ts
+++ b/packages/pgbo-fastify/tests/routes.test.ts
@@ -123,7 +123,7 @@ describe('pgbo-fastify route factory', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/bo/warehouse' })
+      const res = await app.inject({ method: 'GET', url: '/meta/warehouse' })
       const body = res.json()
       expect(res.statusCode).toBe(200)
       expect(body.fields).toBeDefined()


### PR DESCRIPTION
## Bug

Defining a BO without an explicit \`routePrefix\` broke Fastify at boot:

> FastifyError: Method 'GET' already declared for route '/bo/warehouseProduct'

With no \`routePrefix\`, the list route defaulted to \`/bo/{projection.name}\` — the same path used for the metadata endpoint. Fastify rejects duplicate method+path registrations. Every BO that didn't set an explicit prefix couldn't run.

## Fix (breaking URL change)

Metadata moves to \`GET /meta/{projection.name}\`. Value help endpoints and custom action routes stay where they are.

### Why this namespace

- Clean separation: \`/bo/\` for data, \`/meta/\` for schema
- Impossible to collide with list/detail paths regardless of \`routePrefix\` choice
- No magic prefixes like \`/_meta\` that would edge-case conflict with record IDs

### Migration

Frontends calling \`GET /bo/X\` for metadata update to \`GET /meta/X\`. Response shape is unchanged.

## Test plan

- [x] New regression test \`tests/route-prefix-collision.test.ts\` — 4 cases exercising list + detail + metadata + \`app.ready()\` on a projection with no \`routePrefix\`. Without the fix all 4 fail (Fastify boot error). With the fix all 4 pass.
- [x] Existing metadata URLs updated across \`routes.test.ts\`, \`features.test.ts\`, \`projections.test.ts\`
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm test\` — 411 total tests pass
- [x] Changeset: \`@pgbo/fastify\` major (URL change breaks existing frontends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)