### PR TITLE
feat(core): many-to-many compositions via link tables (closes #25, read path)

### DIFF
--- a/.changeset/m2m-link-compositions.md
+++ b/.changeset/m2m-link-compositions.md
@@ -1,0 +1,43 @@
+---
+"@pgbo/core": minor
+---
+
+Many-to-many compositions via link tables (closes #25, read path).
+
+A new `LinkCompositionDef` shape resolves parent → link table → target entity:
+
+```ts
+const productBO = defineBO(productTable, {
+  compositions: {
+    warehouses: {
+      linkTable: productWarehouseTable,
+      linkParentKey: 'wku',
+      linkTargetKey: 'warehouseSlug',
+      target: warehouseBO,
+      columns: ['slug', 'name'],
+      linkWhere: { archived: { isNull: true } },
+      where: { active: true },
+    },
+  },
+})
+```
+
+### Behaviour on read
+
+`enrichCompositions` batches three queries per parent group:
+1. `SELECT FROM linkTable WHERE linkParentKey = ANY($1) [AND linkWhere]`
+2. `SELECT FROM target WHERE target.paramField = ANY(targetKeys) [AND where]`
+3. If `target` is a BO, its own compositions run (e.g. translation resolution — `$locale` placeholders supported via `ctx`).
+
+Each parent gets an array of target rows under the composition name. `columns` narrows the exposed fields per element.
+
+### New exports from `@pgbo/core/bo`
+
+- `LinkCompositionDef` — the M2M shape
+- `AnyCompositionDef` — union of the plain + link-through variants
+- `BoTarget` — structural type for BOs used as composition targets
+- `isLinkComposition(def)` — discriminator helper
+
+### Scope
+
+**Read-only for now.** Write-through support (replace / add / remove semantics for M2M payloads in `bo.create()` / `bo.update()`) is deferred to a follow-up PR — link-data passed in write calls is currently ignored.

--- a/docs/bo.md
+++ b/docs/bo.md
@@ -277,6 +277,42 @@ compositions: {
 // Result: { id, slug, name, description } — no nested 'translation' object
 ```
 
+### Many-to-many via link tables
+
+A third composition shape resolves parent → link table → target entity in two batched queries. Useful for M2M patterns like product↔warehouse assignments where you want each product row to carry the list of warehouses it's assigned to, with target compositions (translations) resolved for free.
+
+```typescript
+const productBO = defineBO(productTable, {
+  paramField: 'wku',
+  compositions: {
+    warehouses: {
+      linkTable: productWarehouseTable,       // junction table
+      linkParentKey: 'wku',                    // FK on link → parent
+      linkTargetKey: 'warehouseSlug',          // FK on link → target
+      target: warehouseBO,                     // BO → its compositions run
+      columns: ['slug', 'name'],               // narrow exposed target fields
+    },
+    activeWarehouses: {
+      linkTable: productWarehouseTable,
+      linkParentKey: 'wku',
+      linkTargetKey: 'warehouseSlug',
+      target: warehouseBO,
+      linkWhere: { archived: { isNull: true } }, // filter on the link rows
+      where: { active: true },                   // filter on the target rows
+    },
+  },
+})
+```
+
+On read, `enrichCompositions` runs three batches per parent group:
+1. `SELECT linkParentKey, linkTargetKey FROM linkTable WHERE linkParentKey = ANY($1) [AND linkWhere]`
+2. `SELECT * FROM target WHERE target.paramField = ANY(targetKeys) [AND where]`
+3. If `target` is a BO, run its own compositions (translations, etc.)
+
+Attached as an array under the composition name: `product.warehouses: [{ slug, name }, ...]` with locale-resolved names when the target is a translated BO.
+
+**Writes are not yet supported** — replace/add/remove semantics for M2M payloads are a follow-up. Passing link data in `bo.create()` input is currently ignored.
+
 ### Nested Sub-Children
 
 Compositions can declare their own `children` for multi-level loading:

--- a/packages/pgbo/src/bo/actions.ts
+++ b/packages/pgbo/src/bo/actions.ts
@@ -59,17 +59,21 @@ export async function executeAction(
       const rows = await db._table.into(table).values(parentData).returning('*').execute()
       result = rows[0]
 
-      // Handle compositions
+      // Handle compositions on create. Link-table compositions (M2M) are
+      // read-only in this version — write support is a follow-up; if the caller
+      // passes link data we ignore it rather than fail.
       for (const [compName, compDef] of Object.entries(bo.compositions)) {
         const compData = data[compName]
         if (!Array.isArray(compData)) continue
+        if ('linkTable' in compDef) continue  // skip link compositions on write
 
-        const compTable = compDef.table ?? compDef.view?.source
+        const plain = compDef
+        const compTable = plain.table ?? plain.view?.source
         if (!compTable) continue
 
         const parentKeyValue = (result as Record<string, unknown>)[bo.paramField]
         for (const childRow of compData as Record<string, unknown>[]) {
-          const childData = { ...childRow, [compDef.parentKey]: parentKeyValue }
+          const childData = { ...childRow, [plain.parentKey]: parentKeyValue }
           await db._table.into(compTable).values(childData).execute()
         }
       }

--- a/packages/pgbo/src/bo/enrich.ts
+++ b/packages/pgbo/src/bo/enrich.ts
@@ -1,9 +1,10 @@
 // Composition auto-enrichment for read operations
-// (issue #018 base + #019 nested children + #13 cardinality/where/merge)
+// (issue #018 base + #019 nested children + #13 cardinality/where/merge + #25 link-table M2M)
 
 import type { Database } from '../query/client.js'
-import type { TableDef } from '../schema/definitions.js'
-import type { BusinessObjectDef, CompositionDef, ActionContext } from './types.js'
+import type { TableDef, ViewDef } from '../schema/definitions.js'
+import type { BusinessObjectDef, CompositionDef, AnyCompositionDef, LinkCompositionDef, BoTarget, ActionContext } from './types.js'
+import { isLinkComposition } from './types.js'
 import { toCamelCase } from '../query/select.js'
 import type { WhereConditions } from '../query/where.js'
 
@@ -39,7 +40,6 @@ function resolveWhere(where: Record<string, unknown>, ctx: ActionContext | undef
   const resolved: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(where)) {
     if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)) {
-      // Operator object like { lte: '$now' } or nested AND/OR
       resolved[key] = resolveWhere(value as Record<string, unknown>, ctx)
     } else if (Array.isArray(value)) {
       resolved[key] = value.map(v => resolvePlaceholder(v, ctx))
@@ -50,58 +50,176 @@ function resolveWhere(where: Record<string, unknown>, ctx: ActionContext | undef
   return resolved
 }
 
+function isBoTarget(value: unknown): value is BoTarget {
+  return typeof value === 'object' && value !== null
+    && 'compositions' in value && 'paramField' in value && 'root' in value
+}
+
+function isViewDefTarget(value: unknown): value is ViewDef {
+  return typeof value === 'object' && value !== null
+    && 'source' in value && !('compositions' in value)
+}
+
+function narrowColumns(row: Record<string, unknown>, columns: readonly string[] | undefined): Record<string, unknown> {
+  if (!columns) return row
+  const result: Record<string, unknown> = {}
+  for (const c of columns) {
+    if (c in row) result[c] = row[c]
+  }
+  return result
+}
+
 export interface EnrichOptions {
   /** Context used to resolve `$locale` / `$userId` / `$tenantId` placeholders in `where`. */
   readonly ctx?: ActionContext
 }
 
+type LevelResult = Map<string, { def: AnyCompositionDef; grouped: Map<unknown, Record<string, unknown>[]> }>
+
+/**
+ * Load link-table composition results for all parent rows.
+ *
+ * Two batched queries:
+ *   1. `SELECT link_parent_key, link_target_key FROM linkTable WHERE link_parent_key = ANY(parentIds) [AND linkWhere]`
+ *   2. `SELECT * FROM target WHERE targetPK = ANY(targetKeys) [AND where]`
+ * (with target BO compositions running on the target rows afterwards)
+ *
+ * Returns a Map<parentValue, targetRow[]> with columns already narrowed per `columns`.
+ */
+async function loadLinkComposition(
+  db: Database,
+  def: LinkCompositionDef,
+  parentIds: unknown[],
+  opts: EnrichOptions,
+): Promise<Map<unknown, Record<string, unknown>[]>> {
+  const grouped = new Map<unknown, Record<string, unknown>[]>()
+  if (parentIds.length === 0) return grouped
+
+  // 1. Load link rows
+  const linkWhere: WhereConditions = { [def.linkParentKey]: { any: parentIds } }
+  if (def.linkWhere) {
+    for (const [k, v] of Object.entries(resolveWhere(def.linkWhere, opts.ctx))) linkWhere[k] = v
+  }
+  const linkRows = await db._table.from(def.linkTable).where(linkWhere).execute() as unknown as Record<string, unknown>[]
+  if (linkRows.length === 0) return grouped
+
+  // 2. Collect distinct target keys
+  const targetKeys = [...new Set(
+    linkRows.map(r => r[def.linkTargetKey]).filter(v => v !== null && v !== undefined),
+  )]
+  if (targetKeys.length === 0) return grouped
+
+  // 3. Load target rows + optionally run target BO compositions
+  const target = def.target
+  let targetPKField: string
+  let targetRows: Record<string, unknown>[]
+
+  if (isBoTarget(target)) {
+    targetPKField = target.paramField
+    const where: WhereConditions = { [targetPKField]: { any: targetKeys } }
+    if (def.where) {
+      for (const [k, v] of Object.entries(resolveWhere(def.where, opts.ctx))) where[k] = v
+    }
+    const root = target.root
+    const rawRows = 'source' in root
+      ? await db.from(root).where(where).execute() as Record<string, unknown>[]
+      : await db._table.from(root).where(where).execute() as unknown as Record<string, unknown>[]
+
+    // Run target BO's own compositions (e.g. translation resolution)
+    const targetBO = target as unknown as BusinessObjectDef
+    targetRows = Object.keys(targetBO.compositions).length > 0
+      ? await enrichCompositions(db, targetBO, rawRows, { ctx: opts.ctx })
+      : rawRows
+  } else if (isViewDefTarget(target)) {
+    const pk = target.source.primaryKey[0]
+    if (!pk) {
+      throw new Error(`Link composition target view "${target.name}" has no primary key`)
+    }
+    targetPKField = pk
+    const where: WhereConditions = { [pk]: { any: targetKeys } }
+    if (def.where) {
+      for (const [k, v] of Object.entries(resolveWhere(def.where, opts.ctx))) where[k] = v
+    }
+    targetRows = await db.from(target).where(where).execute() as Record<string, unknown>[]
+  } else {
+    // Plain TableDef target
+    const targetTable = target as TableDef
+    const pk = targetTable.primaryKey[0]
+    if (!pk) {
+      throw new Error(`Link composition target table "${targetTable.name}" has no primary key`)
+    }
+    targetPKField = pk
+    const where: WhereConditions = { [pk]: { any: targetKeys } }
+    if (def.where) {
+      for (const [k, v] of Object.entries(resolveWhere(def.where, opts.ctx))) where[k] = v
+    }
+    targetRows = await db._table.from(targetTable).where(where).execute() as unknown as Record<string, unknown>[]
+  }
+
+  // 4. Build target-key → row map, then group by parent via link rows
+  const byTargetKey = new Map<unknown, Record<string, unknown>>()
+  for (const row of targetRows) byTargetKey.set(row[targetPKField], row)
+
+  for (const link of linkRows) {
+    const parentValue = link[def.linkParentKey]
+    const targetKey = link[def.linkTargetKey]
+    const targetRow = targetKey !== null && targetKey !== undefined ? byTargetKey.get(targetKey) : undefined
+    if (!targetRow) continue
+    const narrowed = narrowColumns(targetRow, def.columns)
+    const existing = grouped.get(parentValue)
+    if (existing) existing.push(narrowed)
+    else grouped.set(parentValue, [narrowed])
+  }
+
+  return grouped
+}
+
 async function loadCompositionLevel(
   db: Database,
-  compositions: readonly (readonly [string, CompositionDef])[],
+  compositions: readonly (readonly [string, AnyCompositionDef])[],
   parentKeyField: string,
   items: readonly Record<string, unknown>[],
   opts: EnrichOptions,
-): Promise<Map<string, { def: CompositionDef; grouped: Map<unknown, Record<string, unknown>[]> }>> {
-  const resultMap = new Map<string, { def: CompositionDef; grouped: Map<unknown, Record<string, unknown>[]> }>()
+): Promise<LevelResult> {
+  const resultMap: LevelResult = new Map()
   if (compositions.length === 0 || items.length === 0) return resultMap
 
   const parentIds = items.map(item => item[parentKeyField])
 
   const results = await Promise.all(
     compositions.map(async ([compName, compDef]) => {
-      const compTable = resolveTable(compDef)
-      if (!compTable) return { compName, def: compDef, grouped: new Map<unknown, Record<string, unknown>[]>() }
-
-      // Build WHERE: parent_key = ANY(ids), plus any resolved filter clause.
-      const where: WhereConditions = {
-        [compDef.parentKey]: { any: parentIds },
+      if (isLinkComposition(compDef)) {
+        const grouped = await loadLinkComposition(db, compDef, parentIds, opts)
+        return { compName, def: compDef, grouped }
       }
-      if (compDef.where) {
-        const resolved = resolveWhere(compDef.where, opts.ctx)
+
+      const plainDef: CompositionDef = compDef
+      const compTable = resolveTable(plainDef)
+      if (!compTable) return { compName, def: plainDef, grouped: new Map<unknown, Record<string, unknown>[]>() }
+
+      const where: WhereConditions = { [plainDef.parentKey]: { any: parentIds } }
+      if (plainDef.where) {
+        const resolved = resolveWhere(plainDef.where, opts.ctx)
         for (const [k, v] of Object.entries(resolved)) where[k] = v
       }
 
       const rows = await db._table.from(compTable).where(where).execute()
       const camelRows = rows as unknown as Record<string, unknown>[]
 
-      // Group by parent key
       const grouped = new Map<unknown, Record<string, unknown>[]>()
       for (const row of camelRows) {
-        const parentValue = row[compDef.parentKey]
+        const parentValue = row[plainDef.parentKey]
         const existing = grouped.get(parentValue)
-        if (existing) {
-          existing.push(row)
-        } else {
-          grouped.set(parentValue, [row])
-        }
+        if (existing) existing.push(row)
+        else grouped.set(parentValue, [row])
       }
 
       // Recursively load sub-children
-      if (compDef.children && Object.keys(compDef.children).length > 0 && camelRows.length > 0) {
+      if (plainDef.children && Object.keys(plainDef.children).length > 0 && camelRows.length > 0) {
         const childPK = compTable.primaryKey[0]
         if (childPK) {
           const childPKCamel = toCamelCase(childPK)
-          const childCompositions = Object.entries(compDef.children) as (readonly [string, CompositionDef])[]
+          const childCompositions = Object.entries(plainDef.children) as (readonly [string, CompositionDef])[]
 
           const subResults = await loadCompositionLevel(db, childCompositions, childPKCamel, camelRows, opts)
 
@@ -114,7 +232,7 @@ async function loadCompositionLevel(
         }
       }
 
-      return { compName, def: compDef, grouped }
+      return { compName, def: plainDef, grouped }
     }),
   )
 
@@ -125,23 +243,15 @@ async function loadCompositionLevel(
 }
 
 /** Apply cardinality + merge semantics to the children for one parent row. */
-function shapeChildren(def: CompositionDef, children: Record<string, unknown>[]): unknown {
-  if (def.cardinality === 'one') {
-    return children[0] ?? null
-  }
+function shapeChildren(def: AnyCompositionDef, children: Record<string, unknown>[]): unknown {
+  if (isLinkComposition(def)) return children  // link comps are always many
+  if (def.cardinality === 'one') return children[0] ?? null
   return children
 }
 
 /**
- * Batch-load composition children (and sub-children) and attach them to parent rows.
- *
- * For each composition defined on the BO:
- * 1. Collect parent key values from `items` using `bo.paramField`
- * 2. SELECT from comp table WHERE parent_key = ANY($1) [AND <resolved where>]
- * 3. If `children`, recursively load sub-children
- * 4. Apply `cardinality` / `merge` / attach to parent
- *
- * Returns new objects — does not mutate the input array.
+ * Batch-load composition children (plain, link-through, and sub-children) and
+ * attach them to parent rows. Returns new objects — does not mutate input.
  */
 export async function enrichCompositions<T extends Record<string, unknown>>(
   db: Database,
@@ -149,7 +259,7 @@ export async function enrichCompositions<T extends Record<string, unknown>>(
   items: readonly T[],
   opts: EnrichOptions = {},
 ): Promise<T[]> {
-  const compositions = Object.entries(bo.compositions) as (readonly [string, CompositionDef])[]
+  const compositions = Object.entries(bo.compositions) as (readonly [string, AnyCompositionDef])[]
   if (compositions.length === 0 || items.length === 0) {
     return items.map(item => ({ ...item }))
   }
@@ -167,8 +277,7 @@ export async function enrichCompositions<T extends Record<string, unknown>>(
     const parentValue = item[bo.paramField]
     for (const [compName, { def, grouped }] of resultMap) {
       const children = grouped.get(parentValue) ?? []
-      if (def.cardinality === 'one' && def.merge && def.merge.length > 0) {
-        // Lift merge fields onto parent instead of attaching as an object
+      if (!isLinkComposition(def) && def.cardinality === 'one' && def.merge && def.merge.length > 0) {
         const match = children[0]
         if (match) {
           for (const field of def.merge) enriched[field] = match[field]

--- a/packages/pgbo/src/bo/enrich.ts
+++ b/packages/pgbo/src/bo/enrich.ts
@@ -143,7 +143,7 @@ async function loadLinkComposition(
     targetRows = await db.from(target).where(where).execute() as Record<string, unknown>[]
   } else {
     // Plain TableDef target
-    const targetTable = target as TableDef
+    const targetTable = target
     const pk = targetTable.primaryKey[0]
     if (!pk) {
       throw new Error(`Link composition target table "${targetTable.name}" has no primary key`)

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -2,7 +2,7 @@
 
 import type { ViewDef, TableDef, AnyColumnBuilder } from '../schema/definitions.js'
 import type { Database } from '../query/client.js'
-import type { BusinessObjectDef, BOConfig, ActionContext, CompositionDef, AnyCompositionDef, TypedBusinessObject } from './types.js'
+import type { BusinessObjectDef, BOConfig, ActionContext, AnyCompositionDef, TypedBusinessObject } from './types.js'
 import { executeAction } from './actions.js'
 
 function snakeToCamel(s: string): string {
@@ -13,7 +13,7 @@ function normalizeComposition(value: AnyCompositionDef | ViewDef | TableDef): An
   // Link-table M2M composition — pass through as-is
   if ('linkTable' in value) return value
   // Plain composition with explicit config — pass through
-  if ('parentKey' in value) return value as CompositionDef
+  if ('parentKey' in value) return value
   // Shorthand: a TableDef passed directly (legacy shape, parentKey inferred/empty)
   if ('columns' in value) return { table: value as TableDef, parentKey: '' }
   // Shorthand: a ViewDef passed directly

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -2,16 +2,21 @@
 
 import type { ViewDef, TableDef, AnyColumnBuilder } from '../schema/definitions.js'
 import type { Database } from '../query/client.js'
-import type { BusinessObjectDef, BOConfig, ActionContext, CompositionDef, TypedBusinessObject } from './types.js'
+import type { BusinessObjectDef, BOConfig, ActionContext, CompositionDef, AnyCompositionDef, TypedBusinessObject } from './types.js'
 import { executeAction } from './actions.js'
 
 function snakeToCamel(s: string): string {
   return s.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase())
 }
 
-function normalizeComposition(value: CompositionDef | ViewDef | TableDef): CompositionDef {
-  if ('parentKey' in value) return value
+function normalizeComposition(value: AnyCompositionDef | ViewDef | TableDef): AnyCompositionDef {
+  // Link-table M2M composition — pass through as-is
+  if ('linkTable' in value) return value
+  // Plain composition with explicit config — pass through
+  if ('parentKey' in value) return value as CompositionDef
+  // Shorthand: a TableDef passed directly (legacy shape, parentKey inferred/empty)
   if ('columns' in value) return { table: value as TableDef, parentKey: '' }
+  // Shorthand: a ViewDef passed directly
   return { view: value as ViewDef, parentKey: '' }
 }
 
@@ -33,7 +38,7 @@ export function defineBO<
   root: R,
   config: Cfg = {} as Cfg,
 ): TypedBusinessObject<C, ResolveParam<C, Cfg>> {
-  const compositions: Record<string, CompositionDef> = {}
+  const compositions: Record<string, AnyCompositionDef> = {}
   if (config.compositions) {
     for (const [key, value] of Object.entries(config.compositions)) {
       compositions[key] = normalizeComposition(value)
@@ -83,6 +88,6 @@ export function defineBO<
   return impl as unknown as TypedBusinessObject<C, ResolveParam<C, Cfg>>
 }
 
-export { type BusinessObjectDef, type BOConfig, type ActionDef, type ActionContext, type CompositionDef, type TypedBusinessObject, type VirtualFieldMeta, type ProjectionDef, type ProjectionConfig } from './types.js'
+export { type BusinessObjectDef, type BOConfig, type ActionDef, type ActionContext, type CompositionDef, type AnyCompositionDef, type LinkCompositionDef, type BoTarget, type TypedBusinessObject, type VirtualFieldMeta, type ProjectionDef, type ProjectionConfig, isLinkComposition } from './types.js'
 export { enrichCompositions } from './enrich.js'
 export { defineProjection, projectRow, projectionExposes } from './projection.js'

--- a/packages/pgbo/src/bo/types.ts
+++ b/packages/pgbo/src/bo/types.ts
@@ -1,6 +1,18 @@
 // Business Object type definitions — Phase 7 (Step 17)
 
 import type { ViewDef, ValueHelpViewDef, TableDef, AnyColumnBuilder, FieldKind, AssociationDef } from '../schema/definitions.js'
+
+/**
+ * Structural shape of a BO that can act as a link-composition target.
+ * Defined here (rather than importing BusinessObjectDef recursively) so the
+ * type is self-contained. The real BusinessObjectDef satisfies this shape.
+ */
+export interface BoTarget {
+  readonly name: string
+  readonly root: ViewDef | TableDef
+  readonly paramField: string
+  readonly compositions: Readonly<Record<string, unknown>>
+}
 import type { InferRow, InferInsert, InferUpdate } from '../schema/infer.js'
 
 export type ActionContext = Record<string, unknown>;
@@ -35,6 +47,44 @@ export interface CompositionDef {
   readonly merge?: readonly string[]
 }
 
+/**
+ * Many-to-many composition variant (issue #25).
+ *
+ * Parent rows reach target rows through a link table:
+ * `parent → linkTable.linkParentKey = parent.paramField`
+ * `→ target.paramField = linkTable.linkTargetKey`
+ *
+ * On read, `enrichCompositions` loads link rows, looks up targets, runs the
+ * target BO's compositions (so translations resolve), and attaches them to
+ * each parent under the composition name as an array.
+ *
+ * Write-through support (replace/add/remove semantics) is deferred to a
+ * follow-up PR — for now link compositions are **read-only**.
+ */
+export interface LinkCompositionDef {
+  /** Tag used at runtime to discriminate from the plain `CompositionDef` shape. */
+  readonly linkTable: TableDef
+  /** Column on the link table that matches the parent's paramField. */
+  readonly linkParentKey: string
+  /** Column on the link table that matches the target's paramField / primary key. */
+  readonly linkTargetKey: string
+  /** The target entity to resolve — view, table, or BO (BO → its compositions run). */
+  readonly target: ViewDef | TableDef | BoTarget
+  /** Narrow the target columns exposed on each parent element. */
+  readonly columns?: readonly string[]
+  /** Additional WHERE on the target query (context placeholders supported). */
+  readonly where?: Record<string, unknown>
+  /** Additional WHERE on the link table query. */
+  readonly linkWhere?: Record<string, unknown>
+}
+
+/** Union of composition shapes used inside a BO's `compositions` record. */
+export type AnyCompositionDef = CompositionDef | LinkCompositionDef
+
+export function isLinkComposition(def: AnyCompositionDef): def is LinkCompositionDef {
+  return 'linkTable' in def
+}
+
 export interface VirtualFieldMeta {
   readonly key: string
   readonly kind: FieldKind
@@ -50,7 +100,7 @@ export interface BusinessObjectDef {
   readonly root: ViewDef | TableDef
   readonly paramField: string
   readonly actions: Readonly<Record<string, ActionDef>>
-  readonly compositions: Readonly<Record<string, CompositionDef>>
+  readonly compositions: Readonly<Record<string, AnyCompositionDef>>
   readonly associations: Readonly<Record<string, AssociationDef>>
   readonly valueHelps: Readonly<Record<string, ValueHelpViewDef>>
   readonly isReadOnly: boolean
@@ -92,7 +142,7 @@ export interface BOConfig<C extends Record<string, AnyColumnBuilder> = Record<st
   name?: string
   paramField?: string & keyof C
   actions?: Record<string, ActionDef>
-  compositions?: Record<string, CompositionDef | ViewDef | TableDef>
+  compositions?: Record<string, AnyCompositionDef | ViewDef | TableDef>
   associations?: Record<string, AssociationDef>
   valueHelps?: Record<string, ValueHelpViewDef>
   routePrefix?: string

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -195,15 +195,30 @@ export function boMeta(
     }
   }
 
-  // Build compositions
-  const compositions = Object.entries(bo.compositions).map(([name, comp]) => ({
-    name,
-    fields: comp.table
-      ? Object.keys(comp.table.columns)
-      : comp.view
-        ? Object.keys(comp.view.source.columns)
-        : [],
-  }))
+  // Build compositions — supports both plain and link-through variants
+  const compositions = Object.entries(bo.compositions).map(([name, comp]) => {
+    if ('linkTable' in comp) {
+      // Link-through: the exposed shape is the target's columns (narrowed if set)
+      if (comp.columns && comp.columns.length > 0) return { name, fields: [...comp.columns] }
+      const target = comp.target
+      if ('source' in target) return { name, fields: Object.keys(target.source.columns) }
+      if ('columns' in target) return { name, fields: Object.keys(target.columns) }
+      // BO target — fall back to root's columns
+      const root = (target as { root: ViewDef | TableDef }).root
+      return {
+        name,
+        fields: 'source' in root ? Object.keys(root.source.columns) : Object.keys(root.columns),
+      }
+    }
+    return {
+      name,
+      fields: comp.table
+        ? Object.keys(comp.table.columns)
+        : comp.view
+          ? Object.keys(comp.view.source.columns)
+          : [],
+    }
+  })
 
   // Build valueHelps
   const valueHelps = (config?.valueHelps ?? []).map(vh => ({

--- a/packages/pgbo/tests/bo/enrich-link-compositions.test.ts
+++ b/packages/pgbo/tests/bo/enrich-link-compositions.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { view } from '../../src/schema/view.js'
+import { text, integer } from '../../src/schema/types.js'
+import { foreignKey } from '../../src/schema/constraints.js'
+import { defineBO } from '../../src/bo/index.js'
+import { enrichCompositions } from '../../src/bo/enrich.js'
+import { createTestDatabase, type TestDatabase } from '../../src/testing/database.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const warehouseTable = table('warehouse', {
+  columns: { slug: text().notNull(), name: text().notNull() },
+  primaryKey: ['slug'],
+})
+
+const warehouseTranslationTable = table('warehouse_translation', {
+  columns: {
+    warehouseSlug: text().notNull(),
+    locale: text().notNull(),
+    name: text().notNull(),
+  },
+  primaryKey: ['warehouseSlug', 'locale'],
+  foreignKeys: [foreignKey(['warehouseSlug']).references('warehouse', ['slug']).onDelete('CASCADE')],
+})
+
+const productTable = table('product', {
+  columns: {
+    wku: text().notNull(),
+    name: text().notNull(),
+  },
+  primaryKey: ['wku'],
+})
+
+const productWarehouseTable = table('product_warehouse', {
+  columns: {
+    wku: text().notNull(),
+    warehouseSlug: text().notNull(),
+    archived: text(),  // 'yes' / null — test linkWhere
+  },
+  primaryKey: ['wku', 'warehouseSlug'],
+})
+
+const productView = view('product_view').from(productTable)
+const warehouseView = view('warehouse_view').from(warehouseTable)
+
+describe('Link-table compositions (M2M) — issue #25', () => {
+  let testDb: TestDatabase
+
+  // Target BO with a translation composition, so M2M reads get locale-resolved names
+  const warehouseBO = defineBO(warehouseTable, {
+    paramField: 'slug',
+    actions: { create: {} },
+    compositions: {
+      translation: {
+        table: warehouseTranslationTable,
+        parentKey: 'warehouseSlug',
+        cardinality: 'one',
+        where: { locale: '$locale' },
+        merge: ['name'],
+      },
+    },
+  })
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [warehouseTable, warehouseTranslationTable, productTable, productWarehouseTable],
+      seed: [
+        'CREATE OR REPLACE VIEW product_view AS SELECT * FROM product',
+        'CREATE OR REPLACE VIEW warehouse_view AS SELECT * FROM warehouse',
+        "INSERT INTO warehouse (slug, name) VALUES ('main', 'Main'), ('returns', 'Returns'), ('hub', 'Hub')",
+        "INSERT INTO warehouse_translation (warehouse_slug, locale, name) VALUES " +
+          "('main','en','Main Warehouse'), ('main','de','Hauptlager'), " +
+          "('returns','en','Returns Centre'), ('returns','de','Rücksendezentrum'), " +
+          "('hub','en','Logistics Hub'), ('hub','de','Logistik-Hub')",
+        "INSERT INTO product (wku, name) VALUES ('P1', 'Widget'), ('P2', 'Gizmo'), ('P3', 'Thingy')",
+        "INSERT INTO product_warehouse (wku, warehouse_slug, archived) VALUES " +
+          "('P1', 'main', null), ('P1', 'returns', null), ('P1', 'hub', 'yes'), " +
+          "('P2', 'main', null), " +
+          "('P3', 'hub', null)",
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  describe('basic M2M load with BO target', () => {
+    it('attaches target rows grouped per parent', async () => {
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+          },
+        },
+      })
+
+      const items = await testDb.db.from(productView).orderBy('wku', 'asc').execute()
+      const enriched = await enrichCompositions(testDb.db, productBO, items, { ctx: { locale: 'en' } })
+
+      const byWku = Object.fromEntries(enriched.map(p => [p.wku, p.warehouses]))
+
+      const p1Slugs = (byWku['P1'] as any[]).map(w => w.slug).sort()
+      expect(p1Slugs).toEqual(['hub', 'main', 'returns'])
+
+      // Target BO's translation composition ran → each warehouse has locale-resolved `name`
+      const mainForP1 = (byWku['P1'] as any[]).find(w => w.slug === 'main')
+      expect(mainForP1.name).toBe('Main Warehouse')
+
+      expect((byWku['P2'] as any[]).map(w => w.slug)).toEqual(['main'])
+      expect((byWku['P3'] as any[]).map(w => w.slug)).toEqual(['hub'])
+    })
+
+    it('runs target compositions at different locales', async () => {
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+          },
+        },
+      })
+
+      const items = await testDb.db.from(productView).where({ wku: 'P1' }).execute()
+      const de = await enrichCompositions(testDb.db, productBO, items, { ctx: { locale: 'de' } })
+
+      const names = ((de[0] as any).warehouses as any[]).map(w => w.name).sort()
+      expect(names).toEqual(['Hauptlager', 'Logistik-Hub', 'Rücksendezentrum'])
+    })
+  })
+
+  describe('columns narrowing', () => {
+    it('limits the exposed target fields', async () => {
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+            columns: ['slug'],  // hide name, etc.
+          },
+        },
+      })
+
+      const items = await testDb.db.from(productView).where({ wku: 'P2' }).execute()
+      const enriched = await enrichCompositions(testDb.db, productBO, items, { ctx: { locale: 'en' } })
+      const warehouses = (enriched[0] as any).warehouses as Record<string, unknown>[]
+      expect(warehouses).toEqual([{ slug: 'main' }])
+    })
+  })
+
+  describe('linkWhere filters the join rows', () => {
+    it('drops archived links', async () => {
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          activeWarehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+            linkWhere: { archived: { isNull: true } },
+          },
+        },
+      })
+
+      const items = await testDb.db.from(productView).where({ wku: 'P1' }).execute()
+      const enriched = await enrichCompositions(testDb.db, productBO, items, { ctx: { locale: 'en' } })
+      const slugs = ((enriched[0] as any).activeWarehouses as any[]).map(w => w.slug).sort()
+      expect(slugs).toEqual(['main', 'returns'])  // 'hub' was archived → filtered
+    })
+  })
+
+  describe('view target (no BO compositions)', () => {
+    it('merges target view fields without running compositions', async () => {
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseView,  // view, not BO
+          },
+        },
+      })
+
+      const items = await testDb.db.from(productView).where({ wku: 'P2' }).execute()
+      const enriched = await enrichCompositions(testDb.db, productBO, items)
+      const wh = ((enriched[0] as any).warehouses as any[])[0]
+      // `name` here is the raw warehouse.name column, not translation-resolved
+      expect(wh.slug).toBe('main')
+      expect(wh.name).toBe('Main')
+    })
+  })
+
+  describe('no parent rows / no link rows', () => {
+    it('empty parent list → empty enrichment', async () => {
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+          },
+        },
+      })
+      const enriched = await enrichCompositions(testDb.db, productBO, [], { ctx: { locale: 'en' } })
+      expect(enriched).toEqual([])
+    })
+
+    it('parents with no link rows get an empty array', async () => {
+      // New product with no warehouses
+      await testDb.raw("INSERT INTO product (wku, name) VALUES ('P99', 'Orphan')")
+
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+          },
+        },
+      })
+      const items = await testDb.db.from(productView).where({ wku: 'P99' }).execute()
+      const enriched = await enrichCompositions(testDb.db, productBO, items, { ctx: { locale: 'en' } })
+      expect((enriched[0] as any).warehouses).toEqual([])
+
+      await testDb.raw("DELETE FROM product WHERE wku = 'P99'")
+    })
+  })
+
+  describe('coexistence with plain compositions', () => {
+    it('both plain and link-through comps enrich the same parent', async () => {
+      // Add a translation sub-table for products too (borrowing warehouse_translation schema for simplicity)
+      const productTranslationTable = table('product_translation', {
+        columns: {
+          wku: text().notNull(),
+          locale: text().notNull(),
+          name: text().notNull(),
+        },
+        primaryKey: ['wku', 'locale'],
+      })
+
+      await testDb.raw(
+        "CREATE TABLE product_translation (wku text NOT NULL, locale text NOT NULL, name text NOT NULL, PRIMARY KEY (wku, locale))",
+      )
+      await testDb.raw("INSERT INTO product_translation (wku, locale, name) VALUES ('P1', 'en', 'Widget EN'), ('P1', 'de', 'Widget DE')")
+
+      const productBO = defineBO(productTable, {
+        paramField: 'wku',
+        actions: { create: {} },
+        compositions: {
+          translations: {
+            table: productTranslationTable,
+            parentKey: 'wku',
+          },
+          warehouses: {
+            linkTable: productWarehouseTable,
+            linkParentKey: 'wku',
+            linkTargetKey: 'warehouseSlug',
+            target: warehouseBO,
+            columns: ['slug'],
+          },
+        },
+      })
+
+      const items = await testDb.db.from(productView).where({ wku: 'P1' }).execute()
+      const enriched = await enrichCompositions(testDb.db, productBO, items, { ctx: { locale: 'en' } })
+      expect(((enriched[0] as any).translations as any[])).toHaveLength(2)
+      expect(((enriched[0] as any).warehouses as any[]).length).toBeGreaterThan(0)
+
+      await testDb.raw('DROP TABLE product_translation')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

New composition shape \`LinkCompositionDef\` for M2M patterns (product↔warehouse, article↔tag, etc.). Resolves parent → link table → target entity in batched queries. When \`target\` is a BO, its own compositions run — so translations and other context-filtered fields land on the target rows automatically.

\`\`\`ts
const productBO = defineBO(productTable, {
  compositions: {
    warehouses: {
      linkTable: productWarehouseTable,
      linkParentKey: 'wku',
      linkTargetKey: 'warehouseSlug',
      target: warehouseBO,
      columns: ['slug', 'name'],             // narrow exposed target fields
      linkWhere: { archived: { isNull: true } },  // filter on link rows
      where: { active: true },                    // filter on target rows
    },
  },
})

// → product.warehouses: [{ slug: 'main', name: 'Main Warehouse' }, ...]
// with name coming from warehouseBO's translation composition at \$locale
\`\`\`

### Behaviour

Per parent group, \`enrichCompositions\` runs three batches:

1. \`SELECT linkParentKey, linkTargetKey FROM linkTable WHERE linkParentKey = ANY(\$1) [AND linkWhere]\`
2. \`SELECT * FROM target WHERE target.paramField = ANY(targetKeys) [AND where]\`
3. If target is a BO → run its compositions on the target rows (recursive enrichment)

### New exports from \`@pgbo/core/bo\`

- \`LinkCompositionDef\`
- \`AnyCompositionDef\` — union of the plain + link-through variants
- \`BoTarget\` — structural type for BOs used as composition targets
- \`isLinkComposition(def)\` — discriminator helper

Plain \`CompositionDef\` continues to work unchanged; \`BO.compositions\` and \`BOConfig.compositions\` accept the union.

### Scope

**Read-only.** Write-through semantics for M2M payloads in \`bo.create()\`/\`bo.update()\` (replace vs add/remove, from the issue) are deferred to a follow-up PR. \`bo.actions\` currently skips link-compositions on write — passing link data in the input is silently ignored rather than failing.

## Test plan

- [x] \`tests/bo/enrich-link-compositions.test.ts\` — 8 cases covering:
  - Basic M2M with BO target (grouping, target compositions running)
  - Locale resolution on target (EN vs DE)
  - \`columns\` narrowing
  - \`linkWhere\` filters join rows (archived links dropped)
  - View target without compositions
  - Empty parent list / parents with no links
  - Coexistence with a plain composition on the same BO
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm test\` — 415 total tests pass across both packages
- [x] Changeset: \`@pgbo/core\` minor (additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)