### PR TITLE
feat(core): .translatedJoin() view helper (closes #14 — last remaining part)

### DIFF
--- a/.changeset/translated-join.md
+++ b/.changeset/translated-join.md
@@ -1,0 +1,38 @@
+---
+"@pgbo/core": minor
+---
+
+Add `.translatedJoin()` view helper (closes #14 — last remaining part).
+
+Declare a locale-resolved view in the schema instead of writing `current_setting()` SQL by hand:
+
+```ts
+const areaLocalizedView = view('area_localized')
+  .from(areaTable)
+  .translatedJoin(areaTranslationTable, {
+    parentKey: 'areaId',
+    localeColumn: 'locale',
+    localeParam: 'app.locale',
+    fallbackLocale: 'en',           // optional — COALESCE'd into missing translations
+    fields: ['name', 'description'],
+  })
+```
+
+### Generated SQL
+
+Without fallback: one `LEFT JOIN translation t_req ON t_req.<parentKey> = parent.<pk> AND t_req.<localeCol> = current_setting('<param>', true)` plus `t_req.<field>` columns.
+
+With fallback: adds a second `LEFT JOIN translation t_fb ON ... AND t_fb.<localeCol> = '<fallback>'` plus `COALESCE(t_req.<field>, t_fb.<field>) AS <field>` columns so missing translations still return something.
+
+### Pairs with `db.withContext` + `sessionParams`
+
+The locale is resolved per-request via the session-params infrastructure (from PR #16). `db.withContext({ locale: 'de' }, tx => tx.from(view).execute())` transparently filters translations across every query in the scope.
+
+### Constraints
+
+- `.translatedJoin()` cannot be combined with `.columns()` — they both own the output column list. Throws at builder time with a clear message.
+- Source table must have a primary key; the first PK column is used for the join.
+
+### Exports
+
+`TranslatedJoinSpec` type is now exported from `@pgbo/core/schema`.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -267,6 +267,49 @@ FROM stock_document
 - Composite parent keys: `{ parentCol1: 'childCol1', parentCol2: 'childCol2' }`.
 - Optional `where` is raw SQL — qualify columns with the child table name.
 
+### Translated Views — `.translatedJoin()`
+
+Declare a locale-resolved view in the schema instead of writing `current_setting()` SQL by hand. Combined with [`sessionParams` + `db.withContext()`](query.md#request-scoped-context-dbwithcontext) it gives you locale-specific column values with no code-level filtering.
+
+```typescript
+const areaLocalizedView = view('area_localized')
+  .from(areaTable)
+  .translatedJoin(areaTranslationTable, {
+    parentKey: 'areaId',          // FK column on translation → parent
+    localeColumn: 'locale',       // locale column on translation
+    localeParam: 'app.locale',    // Postgres session param to read
+    fallbackLocale: 'en',         // optional — COALESCE'd into missing translations
+    fields: ['name', 'description'],
+  })
+```
+
+Generated DDL:
+```sql
+CREATE VIEW area_localized AS SELECT
+  area.id, area.slug,
+  COALESCE(t_req.name, t_fb.name) AS name,
+  COALESCE(t_req.description, t_fb.description) AS description
+FROM area
+LEFT JOIN area_translation t_req
+  ON t_req.area_id = area.id
+ AND t_req.locale = current_setting('app.locale', true)
+LEFT JOIN area_translation t_fb
+  ON t_fb.area_id = area.id
+ AND t_fb.locale = 'en'
+```
+
+Usage — the locale comes from the request ctx via `db.withContext`:
+
+```typescript
+const rows = await db.withContext({ locale: 'de' }, async tx => {
+  return tx.from(areaLocalizedView).execute()
+})
+// → each row's `name` is the German translation, or the English fallback,
+//   or null if neither exists
+```
+
+Cannot be combined with `.columns()` — `.translatedJoin()` owns the output column list (source columns + translated fields).
+
 ### Value Help Views
 
 Flat read-only views for dropdowns:

--- a/packages/pgbo/src/schema/definitions.ts
+++ b/packages/pgbo/src/schema/definitions.ts
@@ -285,6 +285,25 @@ export interface AssociationDef {
   readonly where?: Record<string, unknown>
 }
 
+/**
+ * Spec for a `.translatedJoin()` view helper — emits LEFT JOINs to a translation
+ * table filtered by a PostgreSQL session param (e.g. `app.locale`), with
+ * optional fallback-locale COALESCE.
+ */
+export interface TranslatedJoinSpec {
+  readonly translationTable: TableDef
+  /** FK column on the translation table that references the parent's PK. */
+  readonly parentKey: string
+  /** Column on the translation table holding the locale code. */
+  readonly localeColumn: string
+  /** Postgres session parameter to read with `current_setting()` — e.g. 'app.locale'. */
+  readonly localeParam: string
+  /** Fields from the translation table to expose as columns on the view. */
+  readonly fields: readonly string[]
+  /** Optional fallback-locale row; output columns become COALESCE(requested, fallback). */
+  readonly fallbackLocale?: string
+}
+
 // --- View ---
 
 export interface ViewDef<
@@ -299,6 +318,7 @@ export interface ViewDef<
   readonly restrictions?: readonly Restriction[]
   readonly isNoAuth?: boolean
   readonly viewAssociations?: Readonly<Record<string, AssociationDef>>
+  readonly translatedJoinSpec?: TranslatedJoinSpec
   /** Phantom type carrying the inferred row shape */
   readonly _rowType?: TRow
   from<C extends Record<string, AnyColumnBuilder>>(table: TableDef<C>): ViewDef<TRow, C>
@@ -312,6 +332,12 @@ export interface ViewDef<
   noAuth(): ViewDef<TRow, SC>
   /** Declare read-time navigation relations. BOs built on this view inherit them. */
   associations(assocs: Record<string, AssociationDef>): ViewDef<TRow, SC>
+  /**
+   * Emit a LEFT JOIN to a translation table filtered by a Postgres session
+   * parameter (`current_setting('app.locale', true)`). Optional fallback-locale
+   * JOIN with COALESCE so missing translations still return something.
+   */
+  translatedJoin(translationTable: TableDef, spec: Omit<TranslatedJoinSpec, 'translationTable'>): ViewDef<TRow, SC>
   /** Brand the view with an explicit row type (escape hatch) */
   as<T extends Record<string, unknown>>(): ViewDef<T>
   toSQL(): string

--- a/packages/pgbo/src/schema/index.ts
+++ b/packages/pgbo/src/schema/index.ts
@@ -25,6 +25,6 @@ export type {
   ForeignKeyDef, ForeignKeyBuilder, IndexDef, IndexBuilder,
   CheckConstraintDef, CheckBuilder, ForeignKeyReference,
   FieldAnnotations, FieldKind, FilterOption, ColumnRef, JoinDef, ValueHelpViewDef, SubqueryCountRef, Restriction,
-  AssociationDef, AssociationTargetBO,
+  AssociationDef, AssociationTargetBO, TranslatedJoinSpec,
 } from './definitions.js'
 export { toSnakeCase } from './table.js'

--- a/packages/pgbo/src/schema/view.ts
+++ b/packages/pgbo/src/schema/view.ts
@@ -1,6 +1,6 @@
 // View builder — Phase 3 (Step 11) + i18n + JOIN support + typed columns
 
-import type { TableDef, ViewDef, ValueHelpViewDef, ColumnRef, JoinDef, SubqueryCountRef, Restriction, AssociationDef } from './definitions.js'
+import type { TableDef, ViewDef, ValueHelpViewDef, ColumnRef, JoinDef, SubqueryCountRef, Restriction, AssociationDef, TranslatedJoinSpec } from './definitions.js'
 import type { TranslatedRef } from './i18n.js'
 import { isTranslatedRef } from './i18n.js'
 import { isSubqueryCountRef } from './subquery.js'
@@ -22,6 +22,7 @@ function createViewDef(
   restrictions?: readonly Restriction[],
   isNoAuth?: boolean,
   viewAssociations?: Readonly<Record<string, AssociationDef>>,
+  translatedJoinSpec?: TranslatedJoinSpec,
 ): ViewDef<any, any> {
   const self: ViewDef = {
     name,
@@ -32,39 +33,56 @@ function createViewDef(
     restrictions,
     isNoAuth,
     viewAssociations,
+    translatedJoinSpec,
 
     from(table: TableDef) {
-      return createViewDef(name, table, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations)
+      return createViewDef(name, table, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
     },
 
     join(table: TableDef, on: Record<string, string>) {
       const newJoin: JoinDef = { table, on, type: 'JOIN' }
-      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations)
+      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
     },
 
     leftJoin(table: TableDef, on: Record<string, string>) {
       const newJoin: JoinDef = { table, on, type: 'LEFT JOIN' }
-      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations)
+      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
     },
 
     columns(cols: Record<string, ColumnEntry>) {
-      return createViewDef(name, source, joins, cols, whereClause, restrictions, isNoAuth, viewAssociations)
+      if (translatedJoinSpec) {
+        throw new Error(
+          `View "${name}": .columns() cannot be combined with .translatedJoin() — use one or the other. ` +
+          `.translatedJoin() already sets the output column list (source columns + translated fields).`,
+        )
+      }
+      return createViewDef(name, source, joins, cols, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
     },
 
     where(condition: string) {
-      return createViewDef(name, source, joins, selectedColumns, condition, restrictions, isNoAuth, viewAssociations)
+      return createViewDef(name, source, joins, selectedColumns, condition, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
     },
 
     restrict(r: Restriction) {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, [...(restrictions ?? []), r], isNoAuth, viewAssociations)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, [...(restrictions ?? []), r], isNoAuth, viewAssociations, translatedJoinSpec)
     },
 
     noAuth() {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, true, viewAssociations)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, true, viewAssociations, translatedJoinSpec)
     },
 
     associations(assocs: Record<string, AssociationDef>) {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, { ...viewAssociations, ...assocs })
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, { ...viewAssociations, ...assocs }, translatedJoinSpec)
+    },
+
+    translatedJoin(translationTable: TableDef, spec: Omit<TranslatedJoinSpec, 'translationTable'>) {
+      if (selectedColumns) {
+        throw new Error(
+          `View "${name}": .translatedJoin() cannot be combined with .columns() — use one or the other.`,
+        )
+      }
+      const fullSpec: TranslatedJoinSpec = { translationTable, ...spec }
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, fullSpec)
     },
 
     as<T extends Record<string, unknown>>() {
@@ -112,6 +130,20 @@ function createViewDef(
         }
       }
 
+      // .translatedJoin() — append COALESCE'd translated columns
+      if (translatedJoinSpec) {
+        const tReq = 't_req'
+        const tFb = 't_fb'
+        for (const field of translatedJoinSpec.fields) {
+          const snakeField = toSnakeCase(field)
+          if (translatedJoinSpec.fallbackLocale) {
+            colParts.push(`COALESCE(${tReq}.${snakeField}, ${tFb}.${snakeField}) AS ${snakeField}`)
+          } else {
+            colParts.push(`${tReq}.${snakeField} AS ${snakeField}`)
+          }
+        }
+      }
+
       let sql = `CREATE VIEW ${name} AS SELECT ${colParts.join(', ')} FROM ${tableName}`
 
       if (joins && joins.length > 0) {
@@ -130,6 +162,29 @@ function createViewDef(
           .map(pk => `${tableName}.${pk} = ${translationTableName}.${pk}`)
           .join(' AND ')
         sql += ` LEFT JOIN ${translationTableName} ON ${joinConditions}`
+      }
+
+      // .translatedJoin() — emit the LEFT JOINs
+      if (translatedJoinSpec) {
+        const parentPK = src.primaryKey[0]
+        if (!parentPK) {
+          throw new Error(`View "${name}": .translatedJoin() requires the source table "${tableName}" to have a primary key`)
+        }
+        const snakePK = toSnakeCase(parentPK)
+        const tt = translatedJoinSpec.translationTable.name
+        const snakeParentKey = toSnakeCase(translatedJoinSpec.parentKey)
+        const snakeLocaleCol = toSnakeCase(translatedJoinSpec.localeColumn)
+
+        sql += ` LEFT JOIN ${tt} t_req`
+          + ` ON t_req.${snakeParentKey} = ${tableName}.${snakePK}`
+          + ` AND t_req.${snakeLocaleCol} = current_setting('${translatedJoinSpec.localeParam}', true)`
+
+        if (translatedJoinSpec.fallbackLocale) {
+          const fb = translatedJoinSpec.fallbackLocale.replace(/'/g, "''")
+          sql += ` LEFT JOIN ${tt} t_fb`
+            + ` ON t_fb.${snakeParentKey} = ${tableName}.${snakePK}`
+            + ` AND t_fb.${snakeLocaleCol} = '${fb}'`
+        }
       }
 
       if (whereClause) {

--- a/packages/pgbo/tests/schema/translated-join.test.ts
+++ b/packages/pgbo/tests/schema/translated-join.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { view } from '../../src/schema/view.js'
+import { text, integer } from '../../src/schema/types.js'
+import { foreignKey } from '../../src/schema/constraints.js'
+import { createTestDatabase, type TestDatabase } from '../../src/testing/database.js'
+import { createDatabase } from '../../src/query/client.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const areaTable = table('area', {
+  columns: { id: integer().notNull(), slug: text().notNull() },
+  primaryKey: ['id'],
+})
+
+const areaTranslationTable = table('area_translation', {
+  columns: {
+    areaId: integer().notNull(),
+    locale: text().notNull(),
+    name: text().notNull(),
+    description: text(),
+  },
+  primaryKey: ['areaId', 'locale'],
+  foreignKeys: [foreignKey(['areaId']).references('area', ['id']).onDelete('CASCADE')],
+})
+
+describe('.translatedJoin() view helper (issue #14)', () => {
+  describe('SQL generation', () => {
+    it('emits a LEFT JOIN filtered by current_setting() without fallback', () => {
+      const v = view('area_localized')
+        .from(areaTable)
+        .translatedJoin(areaTranslationTable, {
+          parentKey: 'areaId',
+          localeColumn: 'locale',
+          localeParam: 'app.locale',
+          fields: ['name'],
+        })
+      const sql = v.toSQL()
+      expect(sql).toContain('CREATE VIEW area_localized AS')
+      expect(sql).toContain('area.id, area.slug')
+      expect(sql).toContain('t_req.name AS name')
+      expect(sql).toContain('LEFT JOIN area_translation t_req')
+      expect(sql).toContain('t_req.area_id = area.id')
+      expect(sql).toContain("t_req.locale = current_setting('app.locale', true)")
+      expect(sql).not.toContain('t_fb')
+      expect(sql).not.toContain('COALESCE')
+    })
+
+    it('emits COALESCE + two LEFT JOINs when fallbackLocale is set', () => {
+      const v = view('area_localized')
+        .from(areaTable)
+        .translatedJoin(areaTranslationTable, {
+          parentKey: 'areaId',
+          localeColumn: 'locale',
+          localeParam: 'app.locale',
+          fallbackLocale: 'en',
+          fields: ['name', 'description'],
+        })
+      const sql = v.toSQL()
+      expect(sql).toContain('COALESCE(t_req.name, t_fb.name) AS name')
+      expect(sql).toContain('COALESCE(t_req.description, t_fb.description) AS description')
+      expect(sql).toContain('LEFT JOIN area_translation t_req')
+      expect(sql).toContain('LEFT JOIN area_translation t_fb')
+      expect(sql).toContain("t_fb.locale = 'en'")
+    })
+
+    it('escapes single quotes in fallback locale', () => {
+      const v = view('area_localized')
+        .from(areaTable)
+        .translatedJoin(areaTranslationTable, {
+          parentKey: 'areaId',
+          localeColumn: 'locale',
+          localeParam: 'app.locale',
+          fallbackLocale: "en'; DROP TABLE area; --",
+          fields: ['name'],
+        })
+      const sql = v.toSQL()
+      expect(sql).toContain("t_fb.locale = 'en''; DROP TABLE area; --'")
+    })
+
+    it('throws when combined with .columns()', () => {
+      expect(() =>
+        view('bad').from(areaTable).columns({}).translatedJoin(areaTranslationTable, {
+          parentKey: 'areaId', localeColumn: 'locale', localeParam: 'app.locale', fields: ['name'],
+        }),
+      ).toThrow(/cannot be combined with \.columns\(\)/)
+    })
+
+    it('throws when .columns() is called after .translatedJoin()', () => {
+      const partial = view('bad').from(areaTable).translatedJoin(areaTranslationTable, {
+        parentKey: 'areaId', localeColumn: 'locale', localeParam: 'app.locale', fields: ['name'],
+      })
+      expect(() => partial.columns({})).toThrow(/cannot be combined with \.translatedJoin\(\)/)
+    })
+
+    it('requires the source table to have a primary key', () => {
+      const brokenTable = table('broken', {
+        columns: { x: text() },
+        primaryKey: [] as unknown as [string],
+      })
+      const v = view('bad').from(brokenTable).translatedJoin(areaTranslationTable, {
+        parentKey: 'areaId', localeColumn: 'locale', localeParam: 'app.locale', fields: ['name'],
+      })
+      expect(() => v.toSQL()).toThrow(/requires the source table .* to have a primary key/)
+    })
+  })
+
+  describe('integration with db.withContext + sessionParams', () => {
+    let testDb: TestDatabase
+
+    const areaLocalizedView = view('area_localized')
+      .from(areaTable)
+      .translatedJoin(areaTranslationTable, {
+        parentKey: 'areaId',
+        localeColumn: 'locale',
+        localeParam: 'app.locale',
+        fallbackLocale: 'en',
+        fields: ['name'],
+      })
+
+    beforeAll(async () => {
+      testDb = await createTestDatabase({
+        connectionString,
+        schema: [areaTable, areaTranslationTable],
+        seed: [
+          areaLocalizedView.toSQL(),
+          "INSERT INTO area (id, slug) VALUES (1, 'nav'), (2, 'admin'), (3, 'orphan')",
+          // 'nav' has both en + de, 'admin' only has en (fallback expected), 'orphan' has nothing
+          "INSERT INTO area_translation (area_id, locale, name) VALUES " +
+            "(1, 'en', 'Navigation'), (1, 'de', 'Navigation DE'), " +
+            "(2, 'en', 'Admin')",
+        ],
+      })
+    })
+
+    afterAll(async () => {
+      await testDb.dispose()
+    })
+
+    it('returns locale-specific name when the translation exists', async () => {
+      const db = createDatabase({
+        connectionString: testDb.connectionString,
+        sessionParams: { 'app.locale': (ctx) => (ctx as { locale?: string }).locale ?? 'en' },
+      })
+
+      const rows = await db.withContext({ locale: 'de' }, async tx => {
+        return tx.from(areaLocalizedView).orderBy('id', 'asc').execute()
+      })
+
+      // nav → German, admin → falls back to English, orphan → null
+      expect(rows.map(r => r.name)).toEqual(['Navigation DE', 'Admin', null])
+      await db.close()
+    })
+
+    it('without withContext, current_setting returns NULL → no locale match; fallback still resolves', async () => {
+      const db = createDatabase({ connectionString: testDb.connectionString })
+      const rows = await db.from(areaLocalizedView).orderBy('id', 'asc').execute()
+
+      // Request locale is NULL so t_req is all nulls — fallback 'en' picks up nav+admin
+      expect(rows.map(r => r.name)).toEqual(['Navigation', 'Admin', null])
+      await db.close()
+    })
+
+    it('switches language based on ctx between calls', async () => {
+      const db = createDatabase({
+        connectionString: testDb.connectionString,
+        sessionParams: { 'app.locale': (ctx) => (ctx as { locale?: string }).locale ?? 'en' },
+      })
+
+      const en = await db.withContext({ locale: 'en' }, async tx => {
+        const r = await tx.from(areaLocalizedView).where({ id: 1 }).execute()
+        return r[0]?.name
+      })
+      const de = await db.withContext({ locale: 'de' }, async tx => {
+        const r = await tx.from(areaLocalizedView).where({ id: 1 }).execute()
+        return r[0]?.name
+      })
+
+      expect(en).toBe('Navigation')
+      expect(de).toBe('Navigation DE')
+      await db.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `.translatedJoin()` to the view builder so locale-resolved views can be declared in the schema instead of writing `current_setting()` SQL by hand.
- Pairs with `db.withContext` + `sessionParams` (PR #16) so the locale flows from request ctx into every query transparently.
- Closes #14 — this was the last remaining deferred piece.

## Generated SQL

Without fallback: one `LEFT JOIN translation t_req ON t_req.<parentKey> = parent.<pk> AND t_req.<localeCol> = current_setting('<param>', true)` plus `t_req.<field>` columns.

With fallback: adds a second `LEFT JOIN translation t_fb ON ... AND t_fb.<localeCol> = '<fallback>'` plus `COALESCE(t_req.<field>, t_fb.<field>) AS <field>` columns so missing translations still return something.

## Constraints

- `.translatedJoin()` cannot be combined with `.columns()` — they both own the output column list. Throws at builder time with a clear message.
- Source table must have a primary key; the first PK column is used for the join.

## Exports

`TranslatedJoinSpec` type is now exported from `@pgbo/core/schema`.

## Test plan

- [x] 9 new tests in [translated-join.test.ts](packages/pgbo/tests/schema/translated-join.test.ts) — SQL generation (with/without fallback, quote escaping, error cases) + integration with `db.withContext` + `sessionParams`
- [x] Full suite: 442 tests pass (386 core + 56 fastify)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)