### PR TITLE
fix(core): materialise value help views via migrate — Option A (closes #31)

### DIFF
--- a/.changeset/value-help-migration.md
+++ b/.changeset/value-help-migration.md
@@ -2,22 +2,28 @@
 "@pgbo/core": minor
 ---
 
-Migrate value help views end-to-end (fixes #31).
+Migrate value help views automatically via registered BOs (fixes #31).
 
-`valueHelpView()` used to declare a DB view via `toSQL()` but nothing ever executed the DDL — `SchemaDefinitions` only accepted `ViewDef[]`. Result: `@pgbo/fastify` 500s with `relation "foo_vh" does not exist` on every value-help endpoint.
+`valueHelpView()` used to declare a DB view via `toSQL()` but nothing ever executed the DDL — `SchemaDefinitions` had no slot that accepted value helps. Result: `@pgbo/fastify` 500s with `relation "foo_vh" does not exist` on every value-help endpoint.
 
-`SchemaDefinitions` now accepts an optional `valueHelps` array, and `diff()` emits `CREATE VIEW` for each entry that isn't already in the snapshot:
+`SchemaDefinitions` now accepts an optional `bos` array. `diff()` walks each BO's `valueHelps`, dedupes by view name (two BOs sharing the same value help produce one `CREATE VIEW`), and emits the DDL for each unique value help that isn't already in the snapshot:
 
 ```ts
 const warehouseVh = valueHelpView('warehouse_vh').from(warehouseTable).key('slug').display('name')
+
+const warehouseBO = defineBO(warehouseView, {
+  name: 'warehouse',
+  paramField: 'id',
+  valueHelps: { warehouse: warehouseVh },
+})
 
 migrate(db, {
   domains: [...],
   enums: [...],
   tables: [warehouseTable],
-  views: [...],
-  valueHelps: [warehouseVh], // ← new
+  views: [warehouseView],
+  bos: [warehouseBO], // ← new
 })
 ```
 
-The field is optional, so existing callers don't need to change.
+Declaring the value help on the BO is now the only wiring needed — no separate registration list. The field is optional, so existing migrate callers don't need to change.

--- a/.changeset/value-help-migration.md
+++ b/.changeset/value-help-migration.md
@@ -1,0 +1,23 @@
+---
+"@pgbo/core": minor
+---
+
+Migrate value help views end-to-end (fixes #31).
+
+`valueHelpView()` used to declare a DB view via `toSQL()` but nothing ever executed the DDL — `SchemaDefinitions` only accepted `ViewDef[]`. Result: `@pgbo/fastify` 500s with `relation "foo_vh" does not exist` on every value-help endpoint.
+
+`SchemaDefinitions` now accepts an optional `valueHelps` array, and `diff()` emits `CREATE VIEW` for each entry that isn't already in the snapshot:
+
+```ts
+const warehouseVh = valueHelpView('warehouse_vh').from(warehouseTable).key('slug').display('name')
+
+migrate(db, {
+  domains: [...],
+  enums: [...],
+  tables: [warehouseTable],
+  views: [...],
+  valueHelps: [warehouseVh], // ← new
+})
+```
+
+The field is optional, so existing callers don't need to change.

--- a/packages/pgbo/src/migration/diff.ts
+++ b/packages/pgbo/src/migration/diff.ts
@@ -2,6 +2,7 @@
 
 import type { DatabaseSnapshot } from './introspect.js'
 import type { TableDef, DomainDef, EnumDef, ViewDef, ValueHelpViewDef } from '../schema/definitions.js'
+import type { BusinessObjectDef } from '../bo/types.js'
 import { toSnakeCase, generateIndexName } from '../schema/table.js'
 
 export interface MigrationOperation {
@@ -26,7 +27,13 @@ export interface SchemaDefinitions {
   readonly enums: readonly EnumDef[]
   readonly tables: readonly TableDef[]
   readonly views: readonly ViewDef[]
-  readonly valueHelps?: readonly ValueHelpViewDef[]
+  /**
+   * Business Objects registered with the schema. migrate() walks `bo.valueHelps`
+   * for each BO, dedupes by name, and emits CREATE VIEW for each unique value help
+   * that doesn't already exist in the database — so declaring a value help on a BO
+   * is all the wiring needed (issue #31).
+   */
+  readonly bos?: readonly BusinessObjectDef[]
 }
 
 export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot): MigrationPlan {
@@ -125,8 +132,8 @@ export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot)
     }
   }
 
-  // --- 6. Value help views (issue #31) ---
-  for (const vh of definitions.valueHelps ?? []) {
+  // --- 6. Value help views discovered via registered BOs (issue #31) ---
+  for (const vh of collectValueHelps(definitions.bos ?? [])) {
     const existing = snapshot.views.find(v => v.name === vh.name)
     if (!existing) {
       operations.push({
@@ -137,6 +144,19 @@ export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot)
   }
 
   return { operations }
+}
+
+/** Walk BOs, collect unique value helps by name. Multiple BOs can share a value help
+ * (e.g. both `warehouseProduct` and `stockJournal` reuse `warehouseValueHelp`) — we emit
+ * CREATE VIEW only once per name. First occurrence wins. */
+function collectValueHelps(bos: readonly BusinessObjectDef[]): ValueHelpViewDef[] {
+  const seen = new Map<string, ValueHelpViewDef>()
+  for (const bo of bos) {
+    for (const vh of Object.values(bo.valueHelps)) {
+      if (!seen.has(vh.name)) seen.set(vh.name, vh)
+    }
+  }
+  return [...seen.values()]
 }
 
 /** Collect all tables including auto-generated translation tables */

--- a/packages/pgbo/src/migration/diff.ts
+++ b/packages/pgbo/src/migration/diff.ts
@@ -1,7 +1,7 @@
 // Schema diff algorithm — Phase 4 (Step 13)
 
 import type { DatabaseSnapshot } from './introspect.js'
-import type { TableDef, DomainDef, EnumDef, ViewDef } from '../schema/definitions.js'
+import type { TableDef, DomainDef, EnumDef, ViewDef, ValueHelpViewDef } from '../schema/definitions.js'
 import { toSnakeCase, generateIndexName } from '../schema/table.js'
 
 export interface MigrationOperation {
@@ -26,6 +26,7 @@ export interface SchemaDefinitions {
   readonly enums: readonly EnumDef[]
   readonly tables: readonly TableDef[]
   readonly views: readonly ViewDef[]
+  readonly valueHelps?: readonly ValueHelpViewDef[]
 }
 
 export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot): MigrationPlan {
@@ -120,6 +121,17 @@ export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot)
       operations.push({
         type: 'createView',
         sql: viewDef.toSQL(),
+      })
+    }
+  }
+
+  // --- 6. Value help views (issue #31) ---
+  for (const vh of definitions.valueHelps ?? []) {
+    const existing = snapshot.views.find(v => v.name === vh.name)
+    if (!existing) {
+      operations.push({
+        type: 'createView',
+        sql: vh.toSQL(),
       })
     }
   }

--- a/packages/pgbo/tests/migration/diff.test.ts
+++ b/packages/pgbo/tests/migration/diff.test.ts
@@ -7,6 +7,7 @@ import { domain } from '../../src/schema/domain.js'
 import { pgEnum } from '../../src/schema/enum.js'
 import { view, valueHelpView } from '../../src/schema/view.js'
 import { index } from '../../src/schema/constraints.js'
+import { defineBO } from '../../src/bo/index.js'
 
 const emptySnapshot: DatabaseSnapshot = {
   domains: [],
@@ -141,14 +142,21 @@ describe('Schema diff', () => {
     expect(tableIdx).toBeLessThan(viewIdx)
   })
 
-  it('detects new value help view (issue #31)', () => {
-    const warehouses = table('warehouse', {
+  it('detects value help views via registered BOs (issue #31)', () => {
+    const warehouse = table('warehouse', {
       columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
       primaryKey: ['id'],
     })
-    const warehouseVh = valueHelpView('warehouse_vh').from(warehouses).key('slug').display('name')
+    const warehouseVh = valueHelpView('warehouse_vh').from(warehouse).key('slug').display('name')
+    const warehouseView = view('warehouse_view').from(warehouse)
+    const warehouseBO = defineBO(warehouseView, {
+      name: 'warehouse',
+      paramField: 'id',
+      valueHelps: { warehouse: warehouseVh },
+    })
+
     const plan = diff(
-      { domains: [], enums: [], tables: [warehouses], views: [], valueHelps: [warehouseVh] },
+      { domains: [], enums: [], tables: [warehouse], views: [warehouseView], bos: [warehouseBO] },
       emptySnapshot,
     )
     const vhOps = plan.operations.filter(op => op.type === 'createView' && op.sql.includes('warehouse_vh'))
@@ -156,30 +164,51 @@ describe('Schema diff', () => {
     expect(vhOps[0]!.sql).toBe('CREATE VIEW warehouse_vh AS SELECT slug, name FROM warehouse')
   })
 
-  it('skips value help view when it already exists in snapshot', () => {
-    const warehouses = table('warehouse', {
+  it('dedupes value helps shared across multiple BOs (same name → one CREATE VIEW)', () => {
+    const warehouse = table('warehouse', {
       columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
       primaryKey: ['id'],
     })
-    const warehouseVh = valueHelpView('warehouse_vh').from(warehouses).key('slug').display('name')
+    const whVh = valueHelpView('warehouse_vh').from(warehouse).key('slug').display('name')
+    const whView = view('warehouse_view').from(warehouse)
+
+    const boA = defineBO(whView, { name: 'boA', paramField: 'id', valueHelps: { wh: whVh } })
+    const boB = defineBO(whView, { name: 'boB', paramField: 'id', valueHelps: { wh: whVh } })
+
+    const plan = diff(
+      { domains: [], enums: [], tables: [warehouse], views: [whView], bos: [boA, boB] },
+      emptySnapshot,
+    )
+    const vhOps = plan.operations.filter(op => op.type === 'createView' && op.sql.includes('warehouse_vh'))
+    expect(vhOps).toHaveLength(1)
+  })
+
+  it('skips value help when the view already exists in snapshot', () => {
+    const warehouse = table('warehouse', {
+      columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
+      primaryKey: ['id'],
+    })
+    const whVh = valueHelpView('warehouse_vh').from(warehouse).key('slug').display('name')
+    const whView = view('warehouse_view').from(warehouse)
+    const bo = defineBO(whView, { name: 'wh', paramField: 'id', valueHelps: { wh: whVh } })
+
     const snapshot: DatabaseSnapshot = {
       ...emptySnapshot,
       views: [{ name: 'warehouse_vh' }],
     }
     const plan = diff(
-      { domains: [], enums: [], tables: [warehouses], views: [], valueHelps: [warehouseVh] },
+      { domains: [], enums: [], tables: [warehouse], views: [whView], bos: [bo] },
       snapshot,
     )
-    const vhOps = plan.operations.filter(op => op.type === 'createView')
+    const vhOps = plan.operations.filter(op => op.sql.includes('warehouse_vh'))
     expect(vhOps).toHaveLength(0)
   })
 
-  it('does not require valueHelps to be set on SchemaDefinitions (backward compat)', () => {
+  it('does not require bos to be set on SchemaDefinitions (backward compat)', () => {
     const users = table('users', {
       columns: { id: integer().notNull(), name: text().notNull() },
       primaryKey: ['id'],
     })
-    // No valueHelps field at all — this must still typecheck and work
     const plan = diff({ domains: [], enums: [], tables: [users], views: [] }, emptySnapshot)
     expect(plan.operations.filter(op => op.type === 'createTable')).toHaveLength(1)
   })

--- a/packages/pgbo/tests/migration/diff.test.ts
+++ b/packages/pgbo/tests/migration/diff.test.ts
@@ -5,7 +5,7 @@ import { table } from '../../src/schema/table.js'
 import { text, integer, timestamp } from '../../src/schema/types.js'
 import { domain } from '../../src/schema/domain.js'
 import { pgEnum } from '../../src/schema/enum.js'
-import { view } from '../../src/schema/view.js'
+import { view, valueHelpView } from '../../src/schema/view.js'
 import { index } from '../../src/schema/constraints.js'
 
 const emptySnapshot: DatabaseSnapshot = {
@@ -139,6 +139,49 @@ describe('Schema diff', () => {
     expect(domainIdx).toBeLessThan(enumIdx)
     expect(enumIdx).toBeLessThan(tableIdx)
     expect(tableIdx).toBeLessThan(viewIdx)
+  })
+
+  it('detects new value help view (issue #31)', () => {
+    const warehouses = table('warehouse', {
+      columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
+      primaryKey: ['id'],
+    })
+    const warehouseVh = valueHelpView('warehouse_vh').from(warehouses).key('slug').display('name')
+    const plan = diff(
+      { domains: [], enums: [], tables: [warehouses], views: [], valueHelps: [warehouseVh] },
+      emptySnapshot,
+    )
+    const vhOps = plan.operations.filter(op => op.type === 'createView' && op.sql.includes('warehouse_vh'))
+    expect(vhOps).toHaveLength(1)
+    expect(vhOps[0]!.sql).toBe('CREATE VIEW warehouse_vh AS SELECT slug, name FROM warehouse')
+  })
+
+  it('skips value help view when it already exists in snapshot', () => {
+    const warehouses = table('warehouse', {
+      columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
+      primaryKey: ['id'],
+    })
+    const warehouseVh = valueHelpView('warehouse_vh').from(warehouses).key('slug').display('name')
+    const snapshot: DatabaseSnapshot = {
+      ...emptySnapshot,
+      views: [{ name: 'warehouse_vh' }],
+    }
+    const plan = diff(
+      { domains: [], enums: [], tables: [warehouses], views: [], valueHelps: [warehouseVh] },
+      snapshot,
+    )
+    const vhOps = plan.operations.filter(op => op.type === 'createView')
+    expect(vhOps).toHaveLength(0)
+  })
+
+  it('does not require valueHelps to be set on SchemaDefinitions (backward compat)', () => {
+    const users = table('users', {
+      columns: { id: integer().notNull(), name: text().notNull() },
+      primaryKey: ['id'],
+    })
+    // No valueHelps field at all — this must still typecheck and work
+    const plan = diff({ domains: [], enums: [], tables: [users], views: [] }, emptySnapshot)
+    expect(plan.operations.filter(op => op.type === 'createTable')).toHaveLength(1)
   })
 
   it('detects auto-generated translation table from .translations()', () => {

--- a/packages/pgbo/tests/migration/execute.test.ts
+++ b/packages/pgbo/tests/migration/execute.test.ts
@@ -7,7 +7,7 @@ import { table } from '../../src/schema/table.js'
 import { text, integer, timestamp } from '../../src/schema/types.js'
 import { domain } from '../../src/schema/domain.js'
 import { pgEnum } from '../../src/schema/enum.js'
-import { view } from '../../src/schema/view.js'
+import { view, valueHelpView } from '../../src/schema/view.js'
 import { index } from '../../src/schema/constraints.js'
 
 const connectionString = process.env['PGBO_TEST_URL'] ?? 'postgresql://localhost:5432/postgres'
@@ -102,6 +102,38 @@ describe('Migration execution', () => {
     // The first table should NOT exist (rolled back)
     const after = await introspect(testDb.db)
     expect(after.tables.find(t => t.name === '_test_tx')).toBeUndefined()
+  })
+
+  it('materialises value help views registered on SchemaDefinitions (issue #31)', async () => {
+    const vhDb = await createTestDatabase({ connectionString, schema: [] })
+    try {
+      const warehouseTable = table('warehouse', {
+        columns: {
+          id: integer().notNull(),
+          slug: text().notNull(),
+          name: text().notNull(),
+        },
+        primaryKey: ['id'],
+      })
+      const warehouseVh = valueHelpView('warehouse_vh').from(warehouseTable).key('slug').display('name')
+
+      const snapshot = await introspect(vhDb.db)
+      const plan = diff(
+        { domains: [], enums: [], tables: [warehouseTable], views: [], valueHelps: [warehouseVh] },
+        snapshot,
+      )
+      await migrate(vhDb.db, plan)
+
+      const after = await introspect(vhDb.db)
+      expect(after.views.find(v => v.name === 'warehouse_vh')).toBeDefined()
+
+      // And it's queryable end-to-end
+      await vhDb.db.query("INSERT INTO warehouse (id, slug, name) VALUES (1, 'main', 'Main')")
+      const rows = await vhDb.db.query<{ slug: string; name: string }>('SELECT * FROM warehouse_vh')
+      expect(rows).toEqual([{ slug: 'main', name: 'Main' }])
+    } finally {
+      await vhDb.dispose()
+    }
   })
 
   it('records migration in _pgbo_migrations table', async () => {

--- a/packages/pgbo/tests/migration/execute.test.ts
+++ b/packages/pgbo/tests/migration/execute.test.ts
@@ -9,6 +9,7 @@ import { domain } from '../../src/schema/domain.js'
 import { pgEnum } from '../../src/schema/enum.js'
 import { view, valueHelpView } from '../../src/schema/view.js'
 import { index } from '../../src/schema/constraints.js'
+import { defineBO } from '../../src/bo/index.js'
 
 const connectionString = process.env['PGBO_TEST_URL'] ?? 'postgresql://localhost:5432/postgres'
 
@@ -104,7 +105,7 @@ describe('Migration execution', () => {
     expect(after.tables.find(t => t.name === '_test_tx')).toBeUndefined()
   })
 
-  it('materialises value help views registered on SchemaDefinitions (issue #31)', async () => {
+  it('materialises value help views discovered via registered BOs (issue #31)', async () => {
     const vhDb = await createTestDatabase({ connectionString, schema: [] })
     try {
       const warehouseTable = table('warehouse', {
@@ -115,11 +116,22 @@ describe('Migration execution', () => {
         },
         primaryKey: ['id'],
       })
+      const warehouseView = view('warehouse_view').from(warehouseTable)
       const warehouseVh = valueHelpView('warehouse_vh').from(warehouseTable).key('slug').display('name')
+      const warehouseBO = defineBO(warehouseView, {
+        name: 'warehouse',
+        paramField: 'id',
+        valueHelps: { warehouse: warehouseVh },
+      })
 
       const snapshot = await introspect(vhDb.db)
       const plan = diff(
-        { domains: [], enums: [], tables: [warehouseTable], views: [], valueHelps: [warehouseVh] },
+        {
+          domains: [], enums: [],
+          tables: [warehouseTable],
+          views: [warehouseView],
+          bos: [warehouseBO],
+        },
         snapshot,
       )
       await migrate(vhDb.db, plan)


### PR DESCRIPTION
## Summary

- `valueHelpView()` declared a DB view via `toSQL()` but nothing ever executed the DDL — `SchemaDefinitions` had no slot that accepted value helps.
- Result: every `@pgbo/fastify` value-help endpoint 500s with \`relation \"foo_vh\" does not exist\` as soon as the frontend opens the corresponding dropdown.
- This PR closes the gap using **Option A from the issue**: `SchemaDefinitions` gets an optional `bos` array, and `diff()` discovers value helps transitively via each BO's `valueHelps`.

## API change

```ts
const warehouseVh = valueHelpView('warehouse_vh').from(warehouseTable).key('slug').display('name')

const warehouseBO = defineBO(warehouseView, {
  name: 'warehouse',
  paramField: 'id',
  valueHelps: { warehouse: warehouseVh },
})

migrate(db, {
  domains: [...],
  enums: [...],
  tables: [warehouseTable],
  views: [warehouseView],
  bos: [warehouseBO], // ← new, optional
})
```

Declaring the value help on the BO is the only wiring needed — no separate registration list, no duplication. If two BOs share a value help, dedupe by name (first occurrence wins → one `CREATE VIEW`).

## Why Option A over B or C

- **A (walking BOs)**: zero duplication — value helps are already attached to BOs, so the schema just registers BOs and migrate discovers everything.
- **B** (explicit `valueHelps: []` slot): forced users to list value helps twice (on the BO and in the schema).
- **C** (Fastify queries source table directly): would have been cleanest but is a behavior change and `valueHelpView.toSQL()` would become dead code.

## Commits in this PR

1. \`fix(core): materialise value help views via migrate\` — initial Option B take (explicit \`valueHelps\` array).
2. \`refactor(core): discover value helps via registered BOs, not explicit list\` — pivot to Option A per user preference.

## Test plan

- [x] New diff test: detects createView for value help reached via \`bos\`
- [x] New diff test: dedupes when two BOs share the same value help
- [x] New diff test: skips when the view already exists in snapshot
- [x] New diff test: \`bos\` is optional — pre-existing callers continue to work
- [x] New end-to-end test: schema + BO → diff → migrate → introspect → \`SELECT\` from the view
- [x] Full suite: 447 tests pass (391 core + 56 fastify)
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)