### PR TITLE
refactor(core)!: replace ValueHelpViewDef with .vh() annotation (closes #34)

### DIFF
--- a/.changeset/vh-annotation.md
+++ b/.changeset/vh-annotation.md
@@ -1,0 +1,63 @@
+---
+"@pgbo/core": minor
+"@pgbo/fastify": minor
+---
+
+Replace `ValueHelpViewDef` with a `.vh({ key, display })` annotation on regular views (closes #34). **Breaking change.**
+
+`valueHelpView()` could only express `SELECT key, display FROM source` — the moment a value help needed a JOIN, a translated label, or a WHERE, it had to be hand-written in Fastify, bypassing the framework. The new shape: a value help is just a regular view with an annotation, so every view feature applies.
+
+### Before
+
+```ts
+const warehouseVH = valueHelpView('warehouse_vh')
+  .from(warehouseTable)
+  .key('slug')
+  .display('name')
+```
+
+### After
+
+```ts
+const warehouseVH = view('warehouse_vh')
+  .from(warehouseTable)
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
+```
+
+Unlocks use cases that were impossible before — translated labels via `translatedJoin`, tenant-scoped value helps via `.where()`, auth-restricted value helps via `.restrict()`, etc.:
+
+```ts
+const uomVh = view('uom_vh')
+  .from(unitOfMeasureTable)
+  .translatedJoin(unitOfMeasureTranslationTable, {
+    parentKey: 'uomSlug', localeColumn: 'locale',
+    localeParam: 'app.locale', fallbackLocale: 'en',
+    fields: ['name', 'symbol'],
+  })
+  .vh({ key: 'slug', display: 'name' })
+```
+
+### Rules
+
+- Value helps must stay flat: `.vh()` and `.associations()` are mutually exclusive — calling one after the other throws at builder time.
+- `defineBO()` throws if any entry in `valueHelps` is a view without a `.vh()` annotation.
+- `col(...).valueHelp(view)` throws if the view isn't `.vh()` annotated.
+
+### Removed
+
+- `valueHelpView()` function
+- `ValueHelpViewDef` type
+- The raw-SQL fallback in `@pgbo/fastify`'s value-help route (it's always a view now → always goes through `paginateView`, so `search`/`limit`/`page` query params just work)
+
+### Migration
+
+Replace each `valueHelpView(name).from(t).key(k).display(d)` with:
+
+```ts
+view(name).from(t).columns({ [k]: col(k), [d]: col(d) }).vh({ key: k, display: d })
+```
+
+### Migration/diff
+
+No change to `SchemaDefinitions.bos` — migrate still walks BO `valueHelps` and emits `CREATE VIEW`. Additionally, if a vh view is registered directly in `views: []`, migrate dedupes it against the `bos` walk so you don't get two identical CREATE VIEW statements.

--- a/docs/bo.md
+++ b/docs/bo.md
@@ -417,9 +417,14 @@ Associations with neither `merge` nor `attach` are metadata-only — no target q
 
 ## Value Helps
 
-Link dropdown sources to a BO:
+Link dropdown sources to a BO. Each entry must be a `view(...).vh({ key, display })` — any other shape throws at `defineBO()` time.
 
 ```typescript
+const warehouseValueHelp = view('warehouse_vh')
+  .from(warehouseTable)
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
+
 const productBO = defineBO(productTable, {
   paramField: 'sku',
   actions: { create: {} },
@@ -428,6 +433,8 @@ const productBO = defineBO(productTable, {
   },
 })
 ```
+
+See the [Value Help Views](schema#value-help-views) section of the schema reference for the full semantics (JOINs, translated labels, auth restrictions).
 
 ## Projections
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -57,7 +57,6 @@ import { boMeta } from '@pgbo/core/metadata'
 
 const meta = boMeta(areaBO, {
   translations: { table: areaTranslationTable, parentKey: 'areaId', fields: ['name'] },
-  valueHelps: [{ name: 'warehouse', view: warehouseView }],
 })
 // {
 //   name: 'area',
@@ -65,9 +64,11 @@ const meta = boMeta(areaBO, {
 //   readOnly: false,
 //   fields: [...viewMeta fields + injected translation fields...],
 //   compositions: [{ name: 'translations', fields: ['areaId', 'locale', 'name'] }],
-//   valueHelps: [{ name: 'warehouse', fields: [...] }],
+//   valueHelps: [{ name: 'warehouse_vh', fields: [...] }],
 // }
 ```
+
+`valueHelps` are picked up directly from the BO — each entry in `bo.valueHelps` is a `ViewDef` with a `.vh({ key, display })` annotation (issue #34). `boMeta` extracts field metadata from each and exposes them under `meta.valueHelps`.
 
 Translation fields are injected as `kind: 'translation'` with `searchable: true` and `filterable: { type: 'text' }` by default.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -176,7 +176,7 @@ DDL: `CREATE TYPE stock_type AS ENUM ('RECEIPT', 'ADJUSTMENT', 'TRANSFER')`
 Views are the **only interface** between application code and the database:
 
 ```typescript
-import { view, valueHelpView, col, translated } from '@pgbo/core/schema'
+import { view, col, translated } from '@pgbo/core/schema'
 
 const warehouseView = view('warehouse_view')
   .from(warehouseTable)
@@ -312,13 +312,26 @@ Cannot be combined with `.columns()` — `.translatedJoin()` owns the output col
 
 ### Value Help Views
 
-Flat read-only views for dropdowns:
+A value help is just a regular view marked with `.vh({ key, display })`. Every view feature — joins, `translatedJoin`, `restrict`, `where` — works as usual. The annotation tells `defineBO()` to accept it as a value help and `@pgbo/fastify` to expose it at `/bo/:name/valueHelp/:vhName`.
 
 ```typescript
-const warehouseValueHelp = valueHelpView('warehouse_vh')
+const warehouseValueHelp = view('warehouse_vh')
   .from(warehouseTable)
-  .key('slug')
-  .display('name')
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
+```
+
+Value helps must stay flat — `.associations()` is forbidden on a vh-annotated view (throws at builder time). If you need a locale-resolved label, combine with `.translatedJoin()`:
+
+```typescript
+const uomVh = view('uom_vh')
+  .from(unitOfMeasureTable)
+  .translatedJoin(unitOfMeasureTranslationTable, {
+    parentKey: 'uomSlug', localeColumn: 'locale',
+    localeParam: 'app.locale', fallbackLocale: 'en',
+    fields: ['name', 'symbol'],
+  })
+  .vh({ key: 'slug', display: 'name' })
 ```
 
 ### Associations
@@ -365,10 +378,11 @@ const warehouseView = view('warehouse_view')
   .columns({ ... })
 
 // Value help — no auth required
-const warehouseVH = valueHelpView('warehouse_vh')
+const warehouseVH = view('warehouse_vh')
   .from(warehouseTable)
+  .columns({ slug: col('slug'), name: col('name') })
   .noAuth()
-  .key('slug').display('name')
+  .vh({ key: 'slug', display: 'name' })
 
 // Additional context (opaque to pgbo — passed to handler as-is)
 const pageView = view('page_view')

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -219,27 +219,16 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
     // so it never collides with the list/detail route prefix (#24).
     app.get(`/meta/${projection.name}`, () => transformProjectionMeta(projection, boMeta(bo)))
 
-    // Value help endpoints
+    // Value help endpoints — each vh is a ViewDef annotated with .vh(), so everything
+    // a regular view supports (search, filters, pagination, restrict, translatedJoin)
+    // just works.
     if (Object.keys(valueHelps).length > 0) {
       for (const [vhName, vh] of Object.entries(valueHelps)) {
         app.get(`/bo/${projection.name}/valueHelp/${vhName}`, async (req: FastifyRequest) => {
           const ctx = await config.extractContext(req)
           const params = parseListParams(req.query as Record<string, unknown>)
-
-          if ('source' in vh && typeof vh.source === 'object') {
-            const result = await paginateView({
-              db, view: vh as ViewDef, params, userId: ctx.userId,
-            })
-            return { items: result.items, total: result.total, page: result.page, limit: result.limit }
-          }
-
-          const offset = (params.page - 1) * params.limit
-          const [items, countRows] = await Promise.all([
-            db.query(`SELECT * FROM ${vh.name} LIMIT ${params.limit} OFFSET ${offset}`),
-            db.query<{ count: string }>(`SELECT COUNT(*) AS count FROM ${vh.name}`),
-          ])
-          const total = Number(countRows[0]?.count ?? 0)
-          return { items, total, page: params.page, limit: params.limit }
+          const result = await paginateView({ db, view: vh, params, userId: ctx.userId })
+          return { items: result.items, total: result.total, page: result.page, limit: result.limit }
         })
       }
     }

--- a/packages/pgbo-fastify/src/types.ts
+++ b/packages/pgbo-fastify/src/types.ts
@@ -2,7 +2,7 @@
 
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type { Database } from '@pgbo/core'
-import type { ViewDef, ValueHelpViewDef } from '@pgbo/core/schema'
+import type { ViewDef } from '@pgbo/core/schema'
 import type { ProjectionDef } from '@pgbo/core/bo'
 
 export interface RouteContext {
@@ -32,7 +32,7 @@ export interface ProjectionRouteConfig {
    * Value help views keyed by name. Registers `GET /bo/{projection.name}/valueHelp/{vhName}`.
    * Defaults to `projection.bo.valueHelps`.
    */
-  readonly valueHelps?: Readonly<Record<string, ViewDef | ValueHelpViewDef>>
+  readonly valueHelps?: Readonly<Record<string, ViewDef>>
 }
 
 /**

--- a/packages/pgbo-fastify/tests/features.test.ts
+++ b/packages/pgbo-fastify/tests/features.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import Fastify from 'fastify'
-import { table, view, valueHelpView, text, integer, col } from '@pgbo/core/schema'
+import { table, view, text, integer, col } from '@pgbo/core/schema'
 import { defineBO, defineProjection } from '@pgbo/core/bo'
 import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
 import { registerProjection } from '../src/index.js'
@@ -24,8 +24,9 @@ const warehouseView = view('warehouse_view').from(warehouseTable).columns({
   tenantId: col('tenantId'),
 })
 
-const warehouseVH = valueHelpView('warehouse_vh')
-  .from(warehouseTable).key('slug').display('name')
+const warehouseVH = view('warehouse_vh').from(warehouseTable)
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
 
 const warehouseBO = defineBO(warehouseTable, {
   paramField: 'slug',

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -49,6 +49,19 @@ export function defineBO<
   const viewAssocs = 'viewAssociations' in root ? root.viewAssociations ?? {} : {}
   const associations = { ...viewAssocs, ...(config.associations ?? {}) }
 
+  // Value helps must be views annotated with .vh() — surface a clear error instead
+  // of letting Fastify fail at request time when it can't find key/display columns.
+  const valueHelps = config.valueHelps ?? {}
+  for (const [vhName, vhView] of Object.entries(valueHelps)) {
+    if (!vhView.vhAnnotation) {
+      const boName = config.name ?? snakeToCamel(root.name)
+      throw new Error(
+        `BO "${boName}": valueHelps["${vhName}"] points to view "${vhView.name}" which has no .vh({ key, display }) annotation. ` +
+        `Mark it as a value help with .vh({ key: '…', display: '…' }) on the view.`,
+      )
+    }
+  }
+
   const bo: BusinessObjectDef = {
     name: config.name ?? snakeToCamel(root.name),
     root,
@@ -56,7 +69,7 @@ export function defineBO<
     actions: config.actions ?? {},
     compositions,
     associations,
-    valueHelps: config.valueHelps ?? {},
+    valueHelps,
     isReadOnly: !config.actions || Object.keys(config.actions).length === 0,
     routePrefix: config.routePrefix,
     orderBy: config.orderBy,

--- a/packages/pgbo/src/bo/types.ts
+++ b/packages/pgbo/src/bo/types.ts
@@ -1,6 +1,6 @@
 // Business Object type definitions — Phase 7 (Step 17)
 
-import type { ViewDef, ValueHelpViewDef, TableDef, AnyColumnBuilder, FieldKind, AssociationDef } from '../schema/definitions.js'
+import type { ViewDef, TableDef, AnyColumnBuilder, FieldKind, AssociationDef } from '../schema/definitions.js'
 
 /**
  * Structural shape of a BO that can act as a link-composition target.
@@ -102,7 +102,7 @@ export interface BusinessObjectDef {
   readonly actions: Readonly<Record<string, ActionDef>>
   readonly compositions: Readonly<Record<string, AnyCompositionDef>>
   readonly associations: Readonly<Record<string, AssociationDef>>
-  readonly valueHelps: Readonly<Record<string, ValueHelpViewDef>>
+  readonly valueHelps: Readonly<Record<string, ViewDef>>
   readonly isReadOnly: boolean
   readonly routePrefix?: string
   readonly orderBy?: string
@@ -144,7 +144,7 @@ export interface BOConfig<C extends Record<string, AnyColumnBuilder> = Record<st
   actions?: Record<string, ActionDef>
   compositions?: Record<string, AnyCompositionDef | ViewDef | TableDef>
   associations?: Record<string, AssociationDef>
-  valueHelps?: Record<string, ValueHelpViewDef>
+  valueHelps?: Record<string, ViewDef>
   routePrefix?: string
   orderBy?: string
   orderDir?: 'asc' | 'desc'

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -1,6 +1,6 @@
 // Annotation-based metadata system
 
-import type { ViewDef, TableDef, ColumnRef, AnyColumnBuilder, FieldKind, ValueHelpViewDef } from '../schema/definitions.js'
+import type { ViewDef, TableDef, ColumnRef, AnyColumnBuilder, FieldKind } from '../schema/definitions.js'
 
 type MetaSource = ViewDef | TableDef
 
@@ -30,7 +30,7 @@ export type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, Enrich
 const numericTypes = new Set(['integer', 'int4', 'serial', 'bigint', 'bigserial', 'numeric', 'real', 'double precision'])
 const dateTypes = new Set(['timestamp', 'timestamptz', 'date'])
 
-function inferKind(pgType: string, annotations: { immutable?: boolean; searchable?: boolean; label?: string; valueHelp?: ValueHelpViewDef }): FieldKind {
+function inferKind(pgType: string, annotations: { immutable?: boolean; searchable?: boolean; label?: string; valueHelp?: ViewDef }): FieldKind {
   if (annotations.valueHelp) return 'relation'
   if (annotations.immutable && annotations.searchable && annotations.label?.includes('slug')) return 'slug'
   if (numericTypes.has(pgType)) return 'number'
@@ -42,17 +42,18 @@ function inferKind(pgType: string, annotations: { immutable?: boolean; searchabl
 function inferFilterMeta(kind: FieldKind, annotations: {
   filterType?: string
   filterOptions?: readonly { value: string; label: string }[]
-  valueHelp?: ValueHelpViewDef
+  valueHelp?: ViewDef
 }): FilterMeta {
   if (annotations.filterType) {
     const meta: FilterMeta = { type: annotations.filterType as FilterMeta['type'] }
     if (annotations.filterOptions) return { ...meta, options: annotations.filterOptions }
-    if (annotations.valueHelp) {
+    const vh = annotations.valueHelp
+    if (vh?.vhAnnotation) {
       return {
         ...meta,
-        endpoint: annotations.valueHelp.name,
-        valueField: annotations.valueHelp.keyField,
-        labelField: annotations.valueHelp.displayField,
+        endpoint: vh.name,
+        valueField: vh.vhAnnotation.key,
+        labelField: vh.vhAnnotation.display,
       }
     }
     return meta
@@ -62,12 +63,12 @@ function inferFilterMeta(kind: FieldKind, annotations: {
     case 'date': return { type: 'date' }
     case 'relation': {
       const vh = annotations.valueHelp
-      if (vh) {
+      if (vh?.vhAnnotation) {
         return {
           type: 'relation',
           endpoint: vh.name,
-          valueField: vh.keyField,
-          labelField: vh.displayField,
+          valueField: vh.vhAnnotation.key,
+          labelField: vh.vhAnnotation.display,
         }
       }
       return { type: 'relation' }
@@ -146,7 +147,7 @@ export function viewMeta(source: ViewDef | TableDef): ViewMeta {
 
 export function boMeta(
   bo: BusinessObjectDef,
-  config?: { translations?: TranslationConfig; valueHelps?: { name: string; view: ViewDef }[] },
+  config?: { translations?: TranslationConfig },
 ): BOMeta {
   const base = viewMeta(bo.root)
 
@@ -220,10 +221,10 @@ export function boMeta(
     }
   })
 
-  // Build valueHelps
-  const valueHelps = (config?.valueHelps ?? []).map(vh => ({
-    name: vh.name,
-    fields: viewMeta(vh.view).fields,
+  // Build valueHelps from the BO's registered views (each is a ViewDef with .vh())
+  const valueHelps = Object.entries(bo.valueHelps).map(([, vhView]) => ({
+    name: vhView.name,
+    fields: viewMeta(vhView).fields,
   }))
 
   // Merge view associations with BO-level associations (BO wins on key collision)

--- a/packages/pgbo/src/migration/diff.ts
+++ b/packages/pgbo/src/migration/diff.ts
@@ -1,7 +1,7 @@
 // Schema diff algorithm — Phase 4 (Step 13)
 
 import type { DatabaseSnapshot } from './introspect.js'
-import type { TableDef, DomainDef, EnumDef, ViewDef, ValueHelpViewDef } from '../schema/definitions.js'
+import type { TableDef, DomainDef, EnumDef, ViewDef } from '../schema/definitions.js'
 import type { BusinessObjectDef } from '../bo/types.js'
 import { toSnakeCase, generateIndexName } from '../schema/table.js'
 
@@ -121,8 +121,25 @@ export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot)
     }
   }
 
-  // --- 5. Views ---
-  for (const viewDef of definitions.views) {
+  // --- 5. Views (explicit + value-help views discovered via registered BOs, issue #31) ---
+  // Value helps are just regular ViewDefs annotated with .vh() (issue #34), so we
+  // union both sources and dedupe by name — users can put vh views in `views:` or
+  // let them flow in via `bos:`, but never both (would be a duplicate CREATE VIEW).
+  const seenViews = new Set<string>()
+  const allViews: ViewDef[] = []
+  for (const v of definitions.views) {
+    if (!seenViews.has(v.name)) {
+      seenViews.add(v.name)
+      allViews.push(v)
+    }
+  }
+  for (const vh of collectValueHelps(definitions.bos ?? [])) {
+    if (!seenViews.has(vh.name)) {
+      seenViews.add(vh.name)
+      allViews.push(vh)
+    }
+  }
+  for (const viewDef of allViews) {
     const existing = snapshot.views.find(v => v.name === viewDef.name)
     if (!existing) {
       operations.push({
@@ -132,25 +149,14 @@ export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot)
     }
   }
 
-  // --- 6. Value help views discovered via registered BOs (issue #31) ---
-  for (const vh of collectValueHelps(definitions.bos ?? [])) {
-    const existing = snapshot.views.find(v => v.name === vh.name)
-    if (!existing) {
-      operations.push({
-        type: 'createView',
-        sql: vh.toSQL(),
-      })
-    }
-  }
-
   return { operations }
 }
 
-/** Walk BOs, collect unique value helps by name. Multiple BOs can share a value help
- * (e.g. both `warehouseProduct` and `stockJournal` reuse `warehouseValueHelp`) — we emit
- * CREATE VIEW only once per name. First occurrence wins. */
-function collectValueHelps(bos: readonly BusinessObjectDef[]): ValueHelpViewDef[] {
-  const seen = new Map<string, ValueHelpViewDef>()
+/** Walk BOs, collect unique value-help views by name. Multiple BOs can share a value
+ * help (e.g. both `warehouseProduct` and `stockJournal` reuse `warehouseValueHelp`) — we
+ * emit CREATE VIEW only once per name. First occurrence wins. */
+function collectValueHelps(bos: readonly BusinessObjectDef[]): ViewDef[] {
+  const seen = new Map<string, ViewDef>()
   for (const bo of bos) {
     for (const vh of Object.values(bo.valueHelps)) {
       if (!seen.has(vh.name)) seen.set(vh.name, vh)

--- a/packages/pgbo/src/schema/column.ts
+++ b/packages/pgbo/src/schema/column.ts
@@ -1,6 +1,6 @@
 // Column reference helper for view select — Phase 3
 
-import type { ColumnRef, FieldAnnotations, FieldKind, FilterOption, ValueHelpViewDef, TableDef, AnyColumnBuilder } from './definitions.js'
+import type { ColumnRef, FieldAnnotations, FieldKind, FilterOption, ViewDef, TableDef, AnyColumnBuilder } from './definitions.js'
 import type { InferColumnType } from './infer.js'
 
 class ColumnRefImpl<T = unknown, R extends string = string> implements ColumnRef<T, R> {
@@ -26,7 +26,15 @@ class ColumnRefImpl<T = unknown, R extends string = string> implements ColumnRef
   hidden(): ColumnRef<T, R> { return this.withAnnotation({ hidden: true }) }
   inList(show: boolean): ColumnRef<T, R> { return this.withAnnotation({ inList: show }) }
   inForm(show: boolean): ColumnRef<T, R> { return this.withAnnotation({ inForm: show }) }
-  valueHelp(vh: ValueHelpViewDef): ColumnRef<T, R> { return this.withAnnotation({ valueHelp: vh }) }
+  valueHelp(vh: ViewDef): ColumnRef<T, R> {
+    if (!vh.vhAnnotation) {
+      throw new Error(
+        `.valueHelp() received view "${vh.name}" that is not annotated with .vh({ key, display }). ` +
+        `Mark the view as a value help with .vh({ key, display }) first.`,
+      )
+    }
+    return this.withAnnotation({ valueHelp: vh })
+  }
   required(): ColumnRef<T, R> { return this.withAnnotation({ required: true }) }
   kind(k: FieldKind): ColumnRef<T, R> { return this.withAnnotation({ kind: k }) }
   filterType(t: 'text' | 'date' | 'select' | 'relation'): ColumnRef<T, R> { return this.withAnnotation({ filterType: t }) }

--- a/packages/pgbo/src/schema/definitions.ts
+++ b/packages/pgbo/src/schema/definitions.ts
@@ -156,7 +156,7 @@ export interface FieldAnnotations {
   readonly hidden?: boolean
   readonly inList?: boolean
   readonly inForm?: boolean
-  readonly valueHelp?: ValueHelpViewDef
+  readonly valueHelp?: ViewDef
   readonly required?: boolean
   readonly kind?: FieldKind
   readonly filterType?: 'text' | 'date' | 'select' | 'relation'
@@ -186,7 +186,7 @@ export interface ColumnRef<T = unknown, R extends string = string> {
   hidden(): ColumnRef<T, R>
   inList(show: boolean): ColumnRef<T, R>
   inForm(show: boolean): ColumnRef<T, R>
-  valueHelp(vh: ValueHelpViewDef): ColumnRef<T, R>
+  valueHelp(vh: ViewDef): ColumnRef<T, R>
   required(): ColumnRef<T, R>
   kind(k: FieldKind): ColumnRef<T, R>
   filterType(t: 'text' | 'date' | 'select' | 'relation'): ColumnRef<T, R>
@@ -286,6 +286,20 @@ export interface AssociationDef {
 }
 
 /**
+ * Annotation that marks a regular view as a value help — a flat, one-row-per-option
+ * source for UI pickers. Set via `.vh({ key, display })` on `ViewDef`. The view
+ * itself is an ordinary `ViewDef` — it supports joins, `translatedJoin`, restrictions,
+ * etc. — but having this annotation tells `@pgbo/fastify` to expose it via the
+ * `/bo/:name/valueHelp/:vhName` route and tells `defineBO` to accept it as a value help.
+ */
+export interface VhAnnotation {
+  /** Column the parent BO stores (the identifier). */
+  readonly key: string
+  /** Column shown to the user (human label). */
+  readonly display: string
+}
+
+/**
  * Spec for a `.translatedJoin()` view helper — emits LEFT JOINs to a translation
  * table filtered by a PostgreSQL session param (e.g. `app.locale`), with
  * optional fallback-locale COALESCE.
@@ -319,6 +333,7 @@ export interface ViewDef<
   readonly isNoAuth?: boolean
   readonly viewAssociations?: Readonly<Record<string, AssociationDef>>
   readonly translatedJoinSpec?: TranslatedJoinSpec
+  readonly vhAnnotation?: VhAnnotation
   /** Phantom type carrying the inferred row shape */
   readonly _rowType?: TRow
   from<C extends Record<string, AnyColumnBuilder>>(table: TableDef<C>): ViewDef<TRow, C>
@@ -338,21 +353,15 @@ export interface ViewDef<
    * JOIN with COALESCE so missing translations still return something.
    */
   translatedJoin(translationTable: TableDef, spec: Omit<TranslatedJoinSpec, 'translationTable'>): ViewDef<TRow, SC>
+  /**
+   * Mark this view as a value help. The view must remain flat (no associations)
+   * and callers must use the `key` + `display` column names referenced here.
+   * Registering the annotation makes `defineBO()` accept the view in `valueHelps`
+   * and makes `@pgbo/fastify` expose it via `/bo/:name/valueHelp/:vhName`.
+   */
+  vh(spec: VhAnnotation): ViewDef<TRow, SC>
   /** Brand the view with an explicit row type (escape hatch) */
   as<T extends Record<string, unknown>>(): ViewDef<T>
-  toSQL(): string
-}
-
-// --- Value help view ---
-
-export interface ValueHelpViewDef {
-  readonly name: string
-  readonly source?: TableDef
-  readonly keyField?: string
-  readonly displayField?: string
-  from(table: TableDef): ValueHelpViewDef
-  key(field: string): ValueHelpViewDef
-  display(field: string): ValueHelpViewDef
   toSQL(): string
 }
 

--- a/packages/pgbo/src/schema/index.ts
+++ b/packages/pgbo/src/schema/index.ts
@@ -1,6 +1,6 @@
 // Schema DSL — tables, views, domains, enums
 export { table } from './table.js'
-export { view, valueHelpView } from './view.js'
+export { view } from './view.js'
 export { domain } from './domain.js'
 export { pgEnum } from './enum.js'
 export { foreignKey, index, check } from './constraints.js'
@@ -24,7 +24,7 @@ export type {
   ColumnBuilder, AnyColumnBuilder, ColumnDef, CheckExpr,
   ForeignKeyDef, ForeignKeyBuilder, IndexDef, IndexBuilder,
   CheckConstraintDef, CheckBuilder, ForeignKeyReference,
-  FieldAnnotations, FieldKind, FilterOption, ColumnRef, JoinDef, ValueHelpViewDef, SubqueryCountRef, Restriction,
-  AssociationDef, AssociationTargetBO, TranslatedJoinSpec,
+  FieldAnnotations, FieldKind, FilterOption, ColumnRef, JoinDef, SubqueryCountRef, Restriction,
+  AssociationDef, AssociationTargetBO, TranslatedJoinSpec, VhAnnotation,
 } from './definitions.js'
 export { toSnakeCase } from './table.js'

--- a/packages/pgbo/src/schema/view.ts
+++ b/packages/pgbo/src/schema/view.ts
@@ -1,6 +1,6 @@
 // View builder — Phase 3 (Step 11) + i18n + JOIN support + typed columns
 
-import type { TableDef, ViewDef, ValueHelpViewDef, ColumnRef, JoinDef, SubqueryCountRef, Restriction, AssociationDef, TranslatedJoinSpec } from './definitions.js'
+import type { TableDef, ViewDef, ColumnRef, JoinDef, SubqueryCountRef, Restriction, AssociationDef, TranslatedJoinSpec, VhAnnotation } from './definitions.js'
 import type { TranslatedRef } from './i18n.js'
 import { isTranslatedRef } from './i18n.js'
 import { isSubqueryCountRef } from './subquery.js'
@@ -23,6 +23,7 @@ function createViewDef(
   isNoAuth?: boolean,
   viewAssociations?: Readonly<Record<string, AssociationDef>>,
   translatedJoinSpec?: TranslatedJoinSpec,
+  vhAnnotation?: VhAnnotation,
 ): ViewDef<any, any> {
   const self: ViewDef = {
     name,
@@ -34,19 +35,20 @@ function createViewDef(
     isNoAuth,
     viewAssociations,
     translatedJoinSpec,
+    vhAnnotation,
 
     from(table: TableDef) {
-      return createViewDef(name, table, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, table, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     join(table: TableDef, on: Record<string, string>) {
       const newJoin: JoinDef = { table, on, type: 'JOIN' }
-      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     leftJoin(table: TableDef, on: Record<string, string>) {
       const newJoin: JoinDef = { table, on, type: 'LEFT JOIN' }
-      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, source, [...(joins ?? []), newJoin], selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     columns(cols: Record<string, ColumnEntry>) {
@@ -56,23 +58,29 @@ function createViewDef(
           `.translatedJoin() already sets the output column list (source columns + translated fields).`,
         )
       }
-      return createViewDef(name, source, joins, cols, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, source, joins, cols, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     where(condition: string) {
-      return createViewDef(name, source, joins, selectedColumns, condition, restrictions, isNoAuth, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, source, joins, selectedColumns, condition, restrictions, isNoAuth, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     restrict(r: Restriction) {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, [...(restrictions ?? []), r], isNoAuth, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, [...(restrictions ?? []), r], isNoAuth, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     noAuth() {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, true, viewAssociations, translatedJoinSpec)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, true, viewAssociations, translatedJoinSpec, vhAnnotation)
     },
 
     associations(assocs: Record<string, AssociationDef>) {
-      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, { ...viewAssociations, ...assocs }, translatedJoinSpec)
+      if (vhAnnotation) {
+        throw new Error(
+          `View "${name}": .associations() cannot be combined with .vh() — value helps must stay flat. ` +
+          `If you need a navigable relation, use a regular view and don't mark it as a value help.`,
+        )
+      }
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, { ...viewAssociations, ...assocs }, translatedJoinSpec, vhAnnotation)
     },
 
     translatedJoin(translationTable: TableDef, spec: Omit<TranslatedJoinSpec, 'translationTable'>) {
@@ -82,7 +90,16 @@ function createViewDef(
         )
       }
       const fullSpec: TranslatedJoinSpec = { translationTable, ...spec }
-      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, fullSpec)
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, fullSpec, vhAnnotation)
+    },
+
+    vh(spec: VhAnnotation) {
+      if (viewAssociations && Object.keys(viewAssociations).length > 0) {
+        throw new Error(
+          `View "${name}": .vh() cannot be combined with .associations() — value helps must stay flat.`,
+        )
+      }
+      return createViewDef(name, source, joins, selectedColumns, whereClause, restrictions, isNoAuth, viewAssociations, translatedJoinSpec, spec)
     },
 
     as<T extends Record<string, unknown>>() {
@@ -200,64 +217,4 @@ function createViewDef(
 
 export function view(name: string): ViewDef<any, any> {
   return createViewDef(name)
-}
-
-export function valueHelpView(name: string): ValueHelpViewDef {
-  const self: ValueHelpViewDef = {
-    name,
-    source: undefined,
-    keyField: undefined,
-    displayField: undefined,
-
-    from(table: TableDef) {
-      return createValueHelpViewDef(name, table, self.keyField, self.displayField)
-    },
-    key(field: string) {
-      return createValueHelpViewDef(name, self.source, field, self.displayField)
-    },
-    display(field: string) {
-      return createValueHelpViewDef(name, self.source, self.keyField, field)
-    },
-    toSQL() {
-      const src = self.source
-      if (!src) throw new Error(`Value help view "${name}" has no source — call .from(table) first`)
-      const cols = [self.keyField, self.displayField]
-        .filter((f): f is string => Boolean(f))
-        .map(f => toSnakeCase(f))
-        .join(', ')
-      return `CREATE VIEW ${name} AS SELECT ${cols} FROM ${src.name}`
-    },
-  }
-  return self
-}
-
-function createValueHelpViewDef(
-  name: string,
-  source?: TableDef,
-  keyField?: string,
-  displayField?: string,
-): ValueHelpViewDef {
-  return {
-    name,
-    source,
-    keyField,
-    displayField,
-    from(table: TableDef) {
-      return createValueHelpViewDef(name, table, keyField, displayField)
-    },
-    key(field: string) {
-      return createValueHelpViewDef(name, source, field, displayField)
-    },
-    display(field: string) {
-      return createValueHelpViewDef(name, source, keyField, field)
-    },
-    toSQL() {
-      if (!source) throw new Error(`Value help view "${name}" has no source — call .from(table) first`)
-      const cols = [keyField, displayField]
-        .filter((f): f is string => Boolean(f))
-        .map(f => toSnakeCase(f))
-        .join(', ')
-      return `CREATE VIEW ${name} AS SELECT ${cols} FROM ${source.name}`
-    },
-  }
 }

--- a/packages/pgbo/tests/metadata/metadata.test.ts
+++ b/packages/pgbo/tests/metadata/metadata.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { table } from '../../src/schema/table.js'
 import { view } from '../../src/schema/view.js'
 import { col } from '../../src/schema/column.js'
-import { valueHelpView } from '../../src/schema/view.js'
 import { text, integer, timestamp, boolean } from '../../src/schema/types.js'
 import { translated, configureI18n } from '../../src/schema/i18n.js'
 import { defineBO } from '../../src/bo/index.js'
@@ -34,10 +33,10 @@ const areaTranslationTable = table('area_translation', {
   primaryKey: ['areaId', 'locale'],
 })
 
-const warehouseVH = valueHelpView('warehouse_vh')
+const warehouseVH = view('warehouse_vh')
   .from(areaTable)
-  .key('slug')
-  .display('name')
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
 
 const areaView = view('area_view').from(areaTable).columns({
   id: col('id').hidden().immutable(),

--- a/packages/pgbo/tests/migration/diff.test.ts
+++ b/packages/pgbo/tests/migration/diff.test.ts
@@ -5,7 +5,8 @@ import { table } from '../../src/schema/table.js'
 import { text, integer, timestamp } from '../../src/schema/types.js'
 import { domain } from '../../src/schema/domain.js'
 import { pgEnum } from '../../src/schema/enum.js'
-import { view, valueHelpView } from '../../src/schema/view.js'
+import { view } from '../../src/schema/view.js'
+import { col } from '../../src/schema/column.js'
 import { index } from '../../src/schema/constraints.js'
 import { defineBO } from '../../src/bo/index.js'
 
@@ -147,7 +148,9 @@ describe('Schema diff', () => {
       columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
       primaryKey: ['id'],
     })
-    const warehouseVh = valueHelpView('warehouse_vh').from(warehouse).key('slug').display('name')
+    const warehouseVh = view('warehouse_vh').from(warehouse)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
     const warehouseView = view('warehouse_view').from(warehouse)
     const warehouseBO = defineBO(warehouseView, {
       name: 'warehouse',
@@ -161,7 +164,8 @@ describe('Schema diff', () => {
     )
     const vhOps = plan.operations.filter(op => op.type === 'createView' && op.sql.includes('warehouse_vh'))
     expect(vhOps).toHaveLength(1)
-    expect(vhOps[0]!.sql).toBe('CREATE VIEW warehouse_vh AS SELECT slug, name FROM warehouse')
+    expect(vhOps[0]!.sql).toContain('CREATE VIEW warehouse_vh AS')
+    expect(vhOps[0]!.sql).toContain('FROM warehouse')
   })
 
   it('dedupes value helps shared across multiple BOs (same name → one CREATE VIEW)', () => {
@@ -169,7 +173,9 @@ describe('Schema diff', () => {
       columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
       primaryKey: ['id'],
     })
-    const whVh = valueHelpView('warehouse_vh').from(warehouse).key('slug').display('name')
+    const whVh = view('warehouse_vh').from(warehouse)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
     const whView = view('warehouse_view').from(warehouse)
 
     const boA = defineBO(whView, { name: 'boA', paramField: 'id', valueHelps: { wh: whVh } })
@@ -183,12 +189,34 @@ describe('Schema diff', () => {
     expect(vhOps).toHaveLength(1)
   })
 
+  it('dedupes vh view against an identically named entry in views: []', () => {
+    const warehouse = table('warehouse', {
+      columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
+      primaryKey: ['id'],
+    })
+    const whVh = view('warehouse_vh').from(warehouse)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
+    const whView = view('warehouse_view').from(warehouse)
+    const bo = defineBO(whView, { name: 'wh', paramField: 'id', valueHelps: { wh: whVh } })
+
+    // Registering the vh view in both views: [] and bos: [] must still emit only one CREATE VIEW.
+    const plan = diff(
+      { domains: [], enums: [], tables: [warehouse], views: [whView, whVh], bos: [bo] },
+      emptySnapshot,
+    )
+    const vhOps = plan.operations.filter(op => op.type === 'createView' && op.sql.includes('warehouse_vh'))
+    expect(vhOps).toHaveLength(1)
+  })
+
   it('skips value help when the view already exists in snapshot', () => {
     const warehouse = table('warehouse', {
       columns: { id: integer().notNull(), slug: text().notNull(), name: text().notNull() },
       primaryKey: ['id'],
     })
-    const whVh = valueHelpView('warehouse_vh').from(warehouse).key('slug').display('name')
+    const whVh = view('warehouse_vh').from(warehouse)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
     const whView = view('warehouse_view').from(warehouse)
     const bo = defineBO(whView, { name: 'wh', paramField: 'id', valueHelps: { wh: whVh } })
 

--- a/packages/pgbo/tests/migration/execute.test.ts
+++ b/packages/pgbo/tests/migration/execute.test.ts
@@ -7,7 +7,8 @@ import { table } from '../../src/schema/table.js'
 import { text, integer, timestamp } from '../../src/schema/types.js'
 import { domain } from '../../src/schema/domain.js'
 import { pgEnum } from '../../src/schema/enum.js'
-import { view, valueHelpView } from '../../src/schema/view.js'
+import { view } from '../../src/schema/view.js'
+import { col } from '../../src/schema/column.js'
 import { index } from '../../src/schema/constraints.js'
 import { defineBO } from '../../src/bo/index.js'
 
@@ -117,7 +118,9 @@ describe('Migration execution', () => {
         primaryKey: ['id'],
       })
       const warehouseView = view('warehouse_view').from(warehouseTable)
-      const warehouseVh = valueHelpView('warehouse_vh').from(warehouseTable).key('slug').display('name')
+      const warehouseVh = view('warehouse_vh').from(warehouseTable)
+        .columns({ slug: col('slug'), name: col('name') })
+        .vh({ key: 'slug', display: 'name' })
       const warehouseBO = defineBO(warehouseView, {
         name: 'warehouse',
         paramField: 'id',

--- a/packages/pgbo/tests/schema/view.test.ts
+++ b/packages/pgbo/tests/schema/view.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { view, valueHelpView } from '../../src/schema/view.js'
+import { view } from '../../src/schema/view.js'
 import { col } from '../../src/schema/column.js'
 import { table } from '../../src/schema/table.js'
 import { text, integer, timestamp } from '../../src/schema/types.js'
@@ -96,38 +96,68 @@ describe('View builder', () => {
       expect(c.annotations.inForm).toBe(false)
     })
 
-    it('.valueHelp(view) links to dropdown source', () => {
-      const vh = valueHelpView('area_vh').from(area).key('slug').display('name')
+    it('.valueHelp(view) links to a vh-annotated view', () => {
+      const vh = view('area_vh').from(area)
+        .columns({ slug: col('slug'), name: col('name') })
+        .vh({ key: 'slug', display: 'name' })
       const c = col('areaSlug').valueHelp(vh)
       expect(c.annotations.valueHelp).toBe(vh)
+    })
+
+    it('.valueHelp() throws when the view is not .vh() annotated', () => {
+      const plainView = view('area_view').from(area)
+      expect(() => col('areaSlug').valueHelp(plainView)).toThrow(/not annotated with \.vh\(/)
     })
   })
 })
 
-describe('Value help view builder', () => {
-  it('creates a flat read-only view', () => {
-    const vh = valueHelpView('area_vh').from(area).key('slug').display('name')
-    expect(vh.name).toBe('area_vh')
-    expect(vh.keyField).toBe('slug')
-    expect(vh.displayField).toBe('name')
-  })
-
-  it('.key() sets the value field', () => {
-    const vh = valueHelpView('area_vh').from(area).key('slug').display('name')
-    expect(vh.keyField).toBe('slug')
-  })
-
-  it('.display() sets the display field', () => {
-    const vh = valueHelpView('area_vh').from(area).key('slug').display('name')
-    expect(vh.displayField).toBe('name')
-  })
-
-  it('generates correct DDL', () => {
-    const vh = valueHelpView('area_vh').from(area).key('slug').display('name')
+describe('.vh() value-help annotation (issue #34)', () => {
+  it('marks a regular view as a value help without changing DDL', () => {
+    const vh = view('area_vh').from(area)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
+    expect(vh.vhAnnotation).toEqual({ key: 'slug', display: 'name' })
+    // DDL is just a normal view — no special branch
     const ddl = vh.toSQL()
     expect(ddl).toContain('CREATE VIEW area_vh AS')
-    expect(ddl).toContain('slug')
-    expect(ddl).toContain('name')
+    expect(ddl).toContain('area.slug')
     expect(ddl).toContain('FROM area')
+  })
+
+  it('supports .translatedJoin() on a vh view (the UoM use case)', () => {
+    const unitOfMeasure = table('unit_of_measure', {
+      columns: { slug: text().notNull() },
+      primaryKey: ['slug'],
+    })
+    const unitOfMeasureTranslation = table('unit_of_measure_translation', {
+      columns: {
+        uomSlug: text().notNull(),
+        locale: text().notNull(),
+        name: text().notNull(),
+        symbol: text().notNull(),
+      },
+      primaryKey: ['uomSlug', 'locale'],
+    })
+    const uomVh = view('uom_vh').from(unitOfMeasure)
+      .translatedJoin(unitOfMeasureTranslation, {
+        parentKey: 'uomSlug', localeColumn: 'locale',
+        localeParam: 'app.locale', fallbackLocale: 'en',
+        fields: ['name', 'symbol'],
+      })
+      .vh({ key: 'slug', display: 'name' })
+    expect(uomVh.vhAnnotation).toEqual({ key: 'slug', display: 'name' })
+    const ddl = uomVh.toSQL()
+    expect(ddl).toContain('LEFT JOIN unit_of_measure_translation t_req')
+    expect(ddl).toContain('COALESCE(t_req.name, t_fb.name) AS name')
+  })
+
+  it('throws when .vh() is followed by .associations()', () => {
+    const vh = view('area_vh').from(area).vh({ key: 'slug', display: 'name' })
+    expect(() => vh.associations({ foo: { foreignKey: 'slug' } })).toThrow(/cannot be combined with \.vh\(\)/)
+  })
+
+  it('throws when .associations() is followed by .vh()', () => {
+    const v = view('area_view').from(area).associations({ foo: { foreignKey: 'slug' } })
+    expect(() => v.vh({ key: 'slug', display: 'name' })).toThrow(/cannot be combined with \.associations\(\)/)
   })
 })


### PR DESCRIPTION
## Summary

`valueHelpView()` could only express `SELECT key, display FROM source`. The moment a value help needed a JOIN, a translated label, or a WHERE, it had to be hand-written in Fastify, bypassing the framework. This PR replaces the parallel DSL branch with a `.vh({ key, display })` annotation on regular views — so every view feature (joins, `translatedJoin`, `restrict`, `where`, session params) now applies to value helps.

## Breaking changes (no backward compat)

- `valueHelpView()` function — removed
- `ValueHelpViewDef` type — removed
- `BOConfig.valueHelps` is now `Record<string, ViewDef>`; `defineBO()` throws at build time if any entry lacks a `.vh()` annotation
- `col(...).valueHelp(view)` throws if the view isn't `.vh()` annotated
- `@pgbo/fastify` drops the raw-SELECT fallback on the value-help route — every vh goes through `paginateView` so `search`/`limit`/`page` query params just work

## Before vs after

\`\`\`ts
// Before
const warehouseVH = valueHelpView('warehouse_vh')
  .from(warehouseTable).key('slug').display('name')

// After
const warehouseVH = view('warehouse_vh').from(warehouseTable)
  .columns({ slug: col('slug'), name: col('name') })
  .vh({ key: 'slug', display: 'name' })
\`\`\`

Unlocks the UoM use case (translated label) that motivated the issue:

\`\`\`ts
const uomVh = view('uom_vh').from(unitOfMeasureTable)
  .translatedJoin(unitOfMeasureTranslationTable, {
    parentKey: 'uomSlug', localeColumn: 'locale',
    localeParam: 'app.locale', fallbackLocale: 'en',
    fields: ['name', 'symbol'],
  })
  .vh({ key: 'slug', display: 'name' })
\`\`\`

## Rules enforced

- `.vh()` and `.associations()` are mutually exclusive on a view — calling one after the other throws at builder time in both directions (value helps must stay flat)
- Migration dedupes vh views that appear in both `views: []` and (via BO walk) `bos: []` — prevents duplicate CREATE VIEW

## Test plan

- [x] New tests: `.vh()` annotation stored + translatedJoin composes + associations forbidden (both directions) + .valueHelp() throws on unannotated view
- [x] Fastify `features.test.ts` updated to use the new API — value-help endpoint still serves rows via `paginateView`
- [x] Migration/diff tests updated: BO-walk still works, plus new test for the `views:` + `bos:` dedup case
- [x] Full suite: 449 tests pass (393 core + 56 fastify)
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean

## Migration guide (for consumers)

Replace each \`valueHelpView(name).from(t).key(k).display(d)\` with:

\`\`\`ts
view(name).from(t).columns({ [k]: col(k), [d]: col(d) }).vh({ key: k, display: d })
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)