### PR TITLE
docs: deep dive on @pgbo/fastify + overhaul metadata guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -58,6 +58,12 @@ export default defineConfig({
           { text: 'Testing', link: '/testing' },
         ],
       },
+      {
+        text: 'Adapters',
+        items: [
+          { text: '@pgbo/fastify', link: '/fastify' },
+        ],
+      },
     ],
 
     socialLinks: [

--- a/docs/fastify.md
+++ b/docs/fastify.md
@@ -1,0 +1,336 @@
+# Fastify Adapter — `@pgbo/fastify`
+
+The Fastify adapter turns a BO **projection** into a complete HTTP surface: list, detail, create, update, delete, custom actions, metadata endpoint, and value-help dropdowns. Nothing is hand-wired — pagination, search, filters, tenant scoping, and column narrowing all derive from the projection + view annotations.
+
+`@pgbo/core` stays framework-agnostic; `@pgbo/fastify` is the thin layer that wires projections to Fastify routes.
+
+## Install
+
+```bash
+npm install @pgbo/fastify fastify
+```
+
+## Minimal end-to-end example
+
+```typescript
+import Fastify from 'fastify'
+import { createDatabase } from '@pgbo/core'
+import { table, view, col, text, integer } from '@pgbo/core/schema'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+import { registerProjection } from '@pgbo/fastify'
+
+// 1. Schema
+const warehouseTable = table('warehouse', {
+  columns: {
+    id: integer().notNull(),
+    slug: text().notNull(),
+    name: text().notNull(),
+    tenantId: text(),
+  },
+  primaryKey: ['id'],
+})
+
+const warehouseView = view('warehouse_view').from(warehouseTable).columns({
+  id: col('id'),
+  slug: col('slug').searchable().label('warehouse.slug'),
+  name: col('name').searchable().filterable(),
+  tenantId: col('tenantId').hidden(),
+})
+
+// 2. BO + projection
+const warehouseBO = defineBO(warehouseTable, {
+  paramField: 'slug',
+  actions: { create: {}, update: {}, delete: {} },
+})
+
+const warehouseProjection = defineProjection(warehouseBO, {
+  name: 'warehouse',
+  actions: { read: true, create: true, update: true, delete: true },
+  // Narrow the public surface — tenantId never leaves the server
+  columns: ['id', 'slug', 'name'],
+})
+
+// 3. Wire to Fastify
+const app = Fastify()
+const db = createDatabase({ connectionString: process.env.DATABASE_URL! })
+
+registerProjection(app, db, {
+  projection: warehouseProjection,
+  view: warehouseView,
+  extractContext: async (req) => ({
+    app, db,
+    tenantId: (req.headers['x-tenant-id'] as string) ?? undefined,
+    userId:   (req.headers['x-user-id']   as string) ?? undefined,
+    locale:   (req.headers['accept-language'] as string)?.slice(0, 2) ?? 'en',
+  }),
+})
+
+await app.listen({ port: 3000 })
+```
+
+This produces, under `/bo/warehouse` (the default prefix):
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET`    | `/bo/warehouse`               | Paginated list (search, filter, sort) |
+| `GET`    | `/bo/warehouse/:slug`         | Detail |
+| `POST`   | `/bo/warehouse`               | Create |
+| `PUT`    | `/bo/warehouse/:slug`         | Update |
+| `DELETE` | `/bo/warehouse/:slug`         | Delete |
+| `GET`    | `/meta/warehouse`             | Frontend-consumable field metadata |
+
+The `:param` segment is driven by `bo.paramField`, not hardcoded to `id`.
+
+## `registerProjection`
+
+```typescript
+function registerProjection(app: FastifyInstance, db: Database, config: ProjectionRouteConfig): void
+
+interface ProjectionRouteConfig {
+  /** The projection — defines the HTTP surface (whitelist, columns, WHERE). */
+  readonly projection: ProjectionDef
+  /** The view to query. Defaults to projection.bo.root if it's a ViewDef. */
+  readonly view?: ViewDef
+  /** Route prefix override. Defaults to projection.bo.routePrefix or `/bo/${projection.name}`. */
+  readonly prefix?: string
+  /** Include global (tenant-less) rows alongside tenant-scoped rows. */
+  readonly includeGlobal?: boolean
+  /** Tenant column name. Default: 'tenantId'. */
+  readonly tenantColumn?: string
+  /** Extract context per request. Called on every route. */
+  readonly extractContext: (req: FastifyRequest) => RouteContext | Promise<RouteContext>
+  /** Hook called after a successful create/update/delete — cache invalidation etc. */
+  readonly afterWrite?: (ctx: RouteContext, action: 'create' | 'update' | 'delete') => void | Promise<void>
+  /** Value-help views keyed by name. Defaults to projection.bo.valueHelps. */
+  readonly valueHelps?: Readonly<Record<string, ViewDef>>
+}
+
+interface RouteContext {
+  readonly app: FastifyInstance
+  readonly db: Database
+  readonly tenantId?: string
+  readonly userId?: string
+  readonly locale: string
+}
+```
+
+### What gets registered
+
+Only whitelisted actions produce routes. `projection.actions.<name>: true` is the only way an action becomes reachable over HTTP — accidental exposure is impossible.
+
+**If `read: true`:**
+
+- `GET {prefix}` — paginated list. Runs composition + association enrichment, applies `transformItems`, attaches `global: true` flag when `includeGlobal`, then narrows to `projection.columns`.
+- `GET {prefix}/:param` — single row by `bo.paramField`. 404 if not found (also 404 if the projection's `where` clause filters it out — invisible rows can't be detail-fetched).
+- `GET /meta/{projection.name}` — field metadata transformed for the frontend (see [Metadata](metadata#meta-name-response-shape)).
+- `GET /bo/{projection.name}/valueHelp/{vhName}` — paginated value help for each entry in `bo.valueHelps`.
+
+**If `create: true`** (and `bo.actions.create` is defined): `POST {prefix}` → 201 on success.
+
+**If `update: true`**: `PUT {prefix}/:param`. Body + `paramField` are merged before dispatching to `bo.update`. 404 for invisible rows; 403 when `includeGlobal` is on and the target row is global.
+
+**If `delete: true`**: `DELETE {prefix}/:param`. Same 404 / 403 semantics as update.
+
+**Custom actions** (`projection.actions.<custom>: true` + `bo.actions.<custom>` handler): `POST /bo/{projection.name}/{custom}`. Body goes straight to the handler. Return `null`/`undefined` → 204; return a `FileResponse` → binary stream; anything else → JSON.
+
+### Tenant scoping + `includeGlobal`
+
+Set `extractContext` to populate `tenantId` from the request (typically a header or JWT claim). The adapter then applies `tenantId = $ctx.tenantId` to every list/detail query — tenant isolation is automatic:
+
+```typescript
+registerProjection(app, db, {
+  projection: warehouseProjection,
+  extractContext: (req) => ({
+    app, db,
+    tenantId: (req.headers['x-tenant-id'] as string),
+    locale: 'en',
+  }),
+})
+```
+
+With `includeGlobal: true`, the WHERE relaxes to `tenantId = $ctx OR tenantId IS NULL`. Rows with null tenant are attached with `global: true` so the frontend can distinguish them. Writes against a global row return **403** — tenants can read globals but not mutate them.
+
+### `afterWrite` hook
+
+Fires after a successful `POST` / `PUT` / `DELETE` (not after custom actions — those own their own side effects). Typical use:
+
+```typescript
+registerProjection(app, db, {
+  projection: warehouseProjection,
+  extractContext: /* ... */,
+  afterWrite: async (ctx, action) => {
+    await cacheInvalidate(ctx.tenantId, 'warehouse')
+    await audit.log({ user: ctx.userId, entity: 'warehouse', action })
+  },
+})
+```
+
+The hook fires *after* the response is computed but *before* the reply is sent, so it can safely await slow side effects.
+
+### Binary responses — `FileResponse`
+
+Custom actions can return a `FileResponse` instead of JSON:
+
+```typescript
+interface FileResponse {
+  readonly data: Buffer | Uint8Array
+  readonly contentType: string
+  readonly filename?: string
+  /** false (default) → attachment; true → inline */
+  readonly inline?: boolean
+}
+```
+
+```typescript
+const docBO = defineBO(docTable, {
+  paramField: 'id',
+  actions: {
+    pdf: {
+      handler: async (ctx, data) => ({
+        data: await renderPdf(data.id),
+        contentType: 'application/pdf',
+        filename: `doc-${data.id}.pdf`,
+      }),
+    },
+  },
+})
+```
+
+`Content-Length` is set from `data.byteLength`. If `filename` is set, `Content-Disposition` gets written with `inline` or `attachment` depending on `inline`. Filename quotes are escaped per RFC 6266.
+
+## `registerViewRoute`
+
+Read-only view routes without a BO. Use this for reporting surfaces that don't need write actions, permissions, or compositions.
+
+```typescript
+function registerViewRoute(app: FastifyInstance, db: Database, config: ViewRouteConfig): void
+
+interface ViewRouteConfig {
+  readonly view: ViewDef
+  /** Default: `/view/${view.name}` */
+  readonly prefix?: string
+  readonly extractContext: (req: FastifyRequest) => RouteContext | Promise<RouteContext>
+}
+```
+
+Produces:
+
+- `GET {prefix}` — paginated list (same query params as projection list — see below)
+- `GET {prefix}/meta` — `viewMeta(view)` output (note: `/meta` *suffix*, not a separate namespace, because there's no projection to disambiguate)
+
+## Pagination + list query params
+
+All list routes (projection list, view route, value-help endpoints) share the same query-string contract, parsed by `parseListParams` from `@pgbo/core/query`:
+
+| Param | Type | Default | Behavior |
+|---|---|---|---|
+| `page`        | int    | `1`     | 1-based |
+| `limit`       | int    | `25`    | Clamped to `[1, 250]` |
+| `search`      | string | `''`    | Applies ILIKE across columns marked `.searchable()` on the view |
+| `sort`        | string | `null`  | Column name — maps to ORDER BY |
+| `order`       | `asc` / `desc` | `asc` | |
+| `filter.<col>`| string | —       | Equality filter on `<col>` — only applied for columns allowed by the view's metadata |
+| `locale`      | string | `'en'`  | Passed into ctx for locale-aware queries |
+| `fields`      | comma-separated | `null` | Subset of columns to return |
+
+Example:
+
+```
+GET /bo/warehouse?search=ship&filter.active=true&sort=name&order=asc&page=2&limit=10
+```
+
+Response shape (`PaginatedResult<T>`):
+
+```typescript
+{
+  items: T[],
+  total: number,   // COUNT(*) with the same WHERE
+  page:  number,
+  limit: number,
+}
+```
+
+### `paginateView` (reusable helper)
+
+If you need pagination inside a custom route, reuse the helper directly:
+
+```typescript
+import { paginateView } from '@pgbo/fastify'
+import { parseListParams } from '@pgbo/core/query'
+
+app.get('/custom/endpoint', async (req) => {
+  const params = parseListParams(req.query as Record<string, unknown>)
+  return paginateView({
+    db,
+    view: myView,
+    params,
+    baseWhere: { status: 'active' },     // AND-combined with filters + search
+    userId: (req.headers['x-user-id'] as string),  // forwarded to .as() for auth
+  })
+})
+```
+
+## `buildTenantWhere`
+
+Manual tenant scoping when you can't use `registerProjection`:
+
+```typescript
+import { buildTenantWhere } from '@pgbo/fastify'
+
+// Strict tenant match
+buildTenantWhere('t1')
+// → { tenantId: 't1' }
+
+// Include global rows (IS NULL)
+buildTenantWhere('t1', 'tenantId', true)
+// → { OR: [{ tenantId: { isNull: true } }, { tenantId: 't1' }] }
+```
+
+Feed the result into `db.from(view).where(...)` or `paginateView({ baseWhere: ... })`.
+
+## Value help endpoints
+
+Any BO with `valueHelps` gets a dropdown endpoint per entry. Value helps are regular views annotated with `.vh({ key, display })` (see [Value Help Views](schema#value-help-views)) — so `search`, `limit`, `page` all work out of the box, and `translatedJoin` / `restrict` / `where` compose naturally:
+
+```typescript
+const uomVh = view('uom_vh').from(uomTable)
+  .translatedJoin(uomTranslationTable, { parentKey: 'uomSlug', localeColumn: 'locale', localeParam: 'app.locale', fallbackLocale: 'en', fields: ['name', 'symbol'] })
+  .vh({ key: 'slug', display: 'name' })
+
+const productBO = defineBO(productTable, {
+  paramField: 'sku',
+  valueHelps: { uom: uomVh },
+})
+```
+
+Request:
+
+```
+GET /bo/product/valueHelp/uom?search=kg&limit=20
+```
+
+Returns the standard `PaginatedResult` shape. The frontend wires each `FilterMeta.endpoint` (see [Metadata](metadata)) to one of these endpoints.
+
+## Complete reference: what routes a projection produces
+
+Given `projection.name = 'warehouse'`, `bo.paramField = 'slug'`, actions `{ read, create, update, delete, pdf }` all whitelisted, and `valueHelps: { region: regionVh }`:
+
+```
+GET    /bo/warehouse                       # list
+GET    /bo/warehouse/:slug                 # detail
+POST   /bo/warehouse                       # create
+PUT    /bo/warehouse/:slug                 # update
+DELETE /bo/warehouse/:slug                 # delete
+POST   /bo/warehouse/pdf                   # custom action
+GET    /meta/warehouse                     # metadata
+GET    /bo/warehouse/valueHelp/region      # value help
+```
+
+The metadata endpoint lives under `/meta/` rather than `/bo/warehouse/meta` so it never collides with a `:slug` that happens to be literally `meta` (issue #24).
+
+## What stays your responsibility
+
+- **Auth**: `extractContext` is where you parse JWTs / session cookies / headers. The adapter never invents a `userId` or `tenantId`.
+- **Schema validation**: use the Zod schemas from [Validation](validation) to validate `req.body` before it reaches `bo.create` / `bo.update`.
+- **Error handling**: Fastify's standard `setErrorHandler` applies. The adapter throws plain `Error`s with descriptive messages — translate them to HTTP responses in your error handler.
+- **CORS, rate limiting, logging, request IDs** — regular Fastify plugins.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,144 +1,312 @@
 # Metadata
 
-pgbo extracts structured metadata from view annotations for use by consuming applications (API frameworks, frontends). No hand-written metadata — everything derives from the schema DSL.
+pgbo extracts structured metadata — field types, labels, filter configs, value-help endpoints — directly from the schema DSL. The same annotations that drive migrations and queries also drive the UI: **the frontend renders lists, forms, and filters from metadata, without a hand-written schema on either side.**
 
-## viewMeta
+```
+view annotations → viewMeta / boMeta → /meta/:name → frontend UI
+```
 
-Extracts field metadata from a view definition:
+## Why metadata?
+
+In a typical CRUD stack you declare each field three times: once in the migration, once in a TypeScript model, once in the frontend form. pgbo collapses this to a single declaration on the column:
+
+```typescript
+import { col } from '@pgbo/core/schema'
+
+col('slug')
+  .label('warehouse.slug')   // i18n key the frontend resolves
+  .searchable()              // appears in the list search box
+  .filterable()              // shows a text filter in the list header
+  .immutable()               // read-only after create
+  .required()                // required in the create form
+```
+
+`viewMeta(view)` walks the column refs and emits the same information as structured data, ready for any UI renderer.
+
+## The flow end-to-end
+
+1. **Column annotations** — `.label()`, `.searchable()`, `.filterable()`, `.valueHelp()`, `.kind()`, etc.
+2. **`viewMeta(view)`** — traverses the view's `columns` + joined tables, infers field kinds from the PG types, returns a `ViewMeta` with typed `FieldMeta[]` entries.
+3. **`boMeta(bo, { translations? })`** — wraps `viewMeta`, plus: injects translation fields, virtual fields, compositions, and value-help references from the BO definition.
+4. **`GET /meta/:projectionName`** — [`@pgbo/fastify`](fastify) transforms the BO meta through the projection: narrows columns to the public whitelist, converts `label` → `labelKey` with fallback, flips `hidden` to `inList: false, inForm: false`.
+5. **Frontend** — fetches the metadata, renders the form/list/filter UI driven purely by the response.
+
+## Fetching metadata
+
+Wire it up once on the server:
+
+```typescript
+// Produces GET /meta/warehouse (plus all CRUD routes)
+registerProjection(app, db, { projection: warehouseProjection, /* ... */ })
+```
+
+Then on the client:
+
+```typescript
+const meta = await fetch('/meta/warehouse').then(r => r.json())
+```
+
+### `/meta/:name` response shape
+
+```typescript
+interface PublicBoMeta {
+  name: string                                  // projection name, not bo.name
+  paramField: string                            // 'slug' → URL param name
+  readOnly: boolean                             // bo.actions empty
+  fields: PublicFieldMeta[]                     // narrowed + transformed
+  associations: AssociationMeta[]               // foreign-key navigations
+  compositions: CompositionMeta[]               // nested children
+  valueHelps: ValueHelpMeta[]                   // dropdown sources
+  routePrefix?: string
+  orderBy?: string
+  orderDir?: 'asc' | 'desc'
+  cacheTags?: string[]
+}
+
+interface PublicFieldMeta {
+  key: string                                   // camelCase, matches JSON payloads
+  kind: 'text' | 'number' | 'date' | 'boolean' | 'slug' | 'relation' | 'translation'
+  labelKey: string                              // always set — fallback to `${projection.name}.${key}`
+  hidden: boolean
+  immutable: boolean                            // disable input in the form
+  searchable: boolean                           // hits the list `?search=` param
+  filterable: false | FilterMeta                // false, or config for the filter widget
+  inList: boolean                               // column visible in list view (false if hidden)
+  inForm: boolean                               // field visible in form view (false if hidden)
+  required: boolean
+  quick: boolean                                // show as a quick filter in the list header
+}
+
+interface FilterMeta {
+  type: 'text' | 'date' | 'select' | 'relation'
+  endpoint?: string                             // value-help URL for 'relation'/'select'
+  valueField?: string                           // column on the target that holds the id
+  labelField?: string                           // column shown to the user
+  options?: { value: string; label: string }[]  // static options for 'select'
+}
+```
+
+### `label` → `labelKey` — the i18n contract
+
+`boMeta().fields[i].label` holds whatever you passed to `.label('some.key')` on the column (or `undefined`). The Fastify layer renames it to `labelKey` and substitutes `${projection.name}.${key}` when it's missing — so **every field always has a labelKey**. The frontend does the actual translation:
+
+```typescript
+// Frontend
+const labelText = i18n.t(field.labelKey)  // 'warehouse.slug' or 'warehouse.createdAt'
+```
+
+This is why labels in metadata look like `"warehouse.slug"`, not `"Slug"`.
+
+## Field kind inference
+
+Kinds are inferred from the column annotations and underlying PG type. The first matching rule wins:
+
+| Condition | `kind` |
+|---|---|
+| `col(...).kind('foo')` | explicit override |
+| `translated('...')` column | `'translation'` |
+| `col(...).valueHelp(vh)` | `'relation'` |
+| `.immutable()` + `.searchable()` + label contains `"slug"` | `'slug'` |
+| PG type is integer / serial / numeric / real / double / bigint | `'number'` |
+| PG type is timestamp / timestamptz / date | `'date'` |
+| PG type is boolean | `'boolean'` |
+| fallback | `'text'` |
+
+The frontend switches on `kind` to pick an input widget (text input, date picker, boolean switch, dropdown, etc.).
+
+## Filterable expansion
+
+`.filterable()` expands into a `FilterMeta` based on `kind`:
+
+- `text` / `slug` → `{ type: 'text' }` (ILIKE search in the filter bar)
+- `date` → `{ type: 'date' }` (date range picker)
+- `relation` → `{ type: 'relation', endpoint, valueField, labelField }` (dropdown fed by the value help)
+
+Override by declaring the filter type explicitly:
+
+```typescript
+col('status')
+  .filterable()
+  .filterType('select')
+  .filterOptions([
+    { value: 'ACTIVE',   label: 'status.active' },
+    { value: 'ARCHIVED', label: 'status.archived' },
+  ])
+```
+
+Or point a filter at a different column (e.g. you filter by `statusCode` but display `statusLabel`):
+
+```typescript
+col('statusLabel').filterable().filterKey('statusCode')
+```
+
+## Driving a list page from metadata
+
+```typescript
+const meta = await fetch('/meta/warehouse').then(r => r.json())
+
+// 1. Column headers
+const columns = meta.fields
+  .filter(f => f.inList)
+  .map(f => ({ key: f.key, label: i18n.t(f.labelKey), sortable: f.kind !== 'relation' }))
+
+// 2. Search box — show only if any field is searchable
+const hasSearch = meta.fields.some(f => f.searchable)
+
+// 3. Quick filters — show in the list header
+const quickFilters = meta.fields.filter(f => f.quick && f.filterable)
+
+// 4. Fetch rows
+const qs = new URLSearchParams({ page: '1', limit: '25', search: searchText })
+for (const [key, value] of Object.entries(activeFilters)) qs.set(`filter.${key}`, value)
+const { items, total } = await fetch(`/bo/warehouse?${qs}`).then(r => r.json())
+```
+
+## Driving a form from metadata
+
+```typescript
+const meta = await fetch('/meta/warehouse').then(r => r.json())
+
+const formFields = meta.fields
+  .filter(f => f.inForm)
+  .map(f => ({
+    key:        f.key,
+    label:      i18n.t(f.labelKey),
+    type:       kindToInputType(f.kind),     // 'text' | 'number' | 'date' | ...
+    required:   f.required,
+    disabled:   f.immutable && mode === 'edit',  // immutable fields locked on edit
+    // For relations, hydrate the dropdown:
+    optionsUrl: f.filterable && f.filterable.type === 'relation'
+      ? f.filterable.endpoint                // e.g. '/bo/warehouse/valueHelp/region'
+      : undefined,
+  }))
+```
+
+Submit the form straight to the CRUD route:
+
+```typescript
+await fetch('/bo/warehouse', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(formValues),
+})
+```
+
+## Value helps & the relation flow
+
+When a column is `.valueHelp(someVhView)`, metadata emits `filterable.endpoint` pointing at the Fastify route that serves the vh. The frontend renders an autocomplete / dropdown that hits:
+
+```
+GET /bo/warehouse/valueHelp/region?search=north&limit=20
+```
+
+and uses `valueField` + `labelField` from the `FilterMeta` (or the vh's `fields`) to render each option. Because value helps are regular views, they support [`translatedJoin`](schema#translated-views-—-translatedjoin), [auth restrictions](schema#auth-restrictions), and arbitrary `where` clauses — all transparent to the frontend.
+
+See [Value Help Views](schema#value-help-views) for the declaration side and [Fastify → Value help endpoints](fastify#value-help-endpoints) for the route contract.
+
+## Column narrowing via projections
+
+If `projection.columns` is set, `/meta/:name` **only** returns those fields — metadata, list responses, and detail responses are all narrowed in lockstep. That's the only supported way to hide a column from the public API while keeping it available to internal writes (hooks, actions, custom handlers):
+
+```typescript
+const projection = defineProjection(warehouseBO, {
+  name: 'warehouse',
+  actions: { read: true },
+  columns: ['id', 'slug', 'name'],           // tenantId stays server-only
+})
+```
+
+## Server-side helpers
+
+`viewMeta` / `boMeta` are also useful directly on the server — e.g. from CLI scripts or custom routes — and `searchWhere`, `filterWhere`, `enrichItems` cover three common building blocks.
+
+### `viewMeta(source)`
 
 ```typescript
 import { viewMeta } from '@pgbo/core/metadata'
 
-const meta = viewMeta(areaView)
+const meta = viewMeta(warehouseView)
 // {
-//   name: 'area_view',
+//   name: 'warehouse_view',
 //   fields: [
-//     { key: 'slug', kind: 'slug', label: 'area.slug', searchable: true, filterable: { type: 'text' }, immutable: true, ... },
-//     { key: 'sortOrder', kind: 'number', label: 'area.sortOrder', ... },
-//     { key: 'name', kind: 'translation', ... },
-//   ]
+//     { key: 'slug', kind: 'slug', label: 'warehouse.slug', searchable: true, filterable: { type: 'text' }, immutable: true, ... },
+//     ...
+//   ],
+//   associations: [{ name: 'region', foreignKey: 'regionId', target: 'region_view' }],
 // }
 ```
 
-`viewMeta` also accepts a `TableDef` directly (infers fields from the table's columns).
+Accepts a `ViewDef` *or* a `TableDef` (useful for infra scripts that don't need a view). For tables without annotations you still get every column with inferred kind — no labels, no searchable, no filterable.
 
-### Field Kind Inference
-
-| Condition | Kind |
-|-----------|------|
-| Has `.valueHelp()` | `'relation'` |
-| `.immutable()` + `.searchable()` + label contains "slug" | `'slug'` |
-| Integer / serial / numeric / real / bigint | `'number'` |
-| Timestamp / date | `'date'` |
-| Boolean | `'boolean'` |
-| `translated()` column | `'translation'` |
-| Default | `'text'` |
-
-Override with `.kind('date')` for explicit control.
-
-### Filterable Expansion
-
-When a column has `.filterable()`, the metadata expands it based on kind:
-
-```typescript
-// kind: 'text' / 'slug'  → { type: 'text' }
-// kind: 'date'            → { type: 'date' }
-// kind: 'relation'        → { type: 'relation', endpoint, valueField, labelField }
-```
-
-Override with `.filterType('select').filterOptions([...])`.
-
-## boMeta
-
-Extends `viewMeta` with BO-specific information:
+### `boMeta(bo, config?)`
 
 ```typescript
 import { boMeta } from '@pgbo/core/metadata'
 
-const meta = boMeta(areaBO, {
-  translations: { table: areaTranslationTable, parentKey: 'areaId', fields: ['name'] },
-  valueHelps: [{ name: 'warehouse', view: warehouseView }],
+const meta = boMeta(warehouseBO, {
+  translations: { table: warehouseTranslationTable, parentKey: 'warehouseId', fields: ['name'] },
 })
-// {
-//   name: 'area',
-//   paramField: 'id',
-//   readOnly: false,
-//   fields: [...viewMeta fields + injected translation fields...],
-//   compositions: [{ name: 'translations', fields: ['areaId', 'locale', 'name'] }],
-//   valueHelps: [{ name: 'warehouse', fields: [...] }],
-// }
+// Extends viewMeta with:
+//   paramField, readOnly, compositions, valueHelps, routePrefix, orderBy, orderDir, cacheTags
+//   + injected translation fields (kind: 'translation', searchable: true, filterable: { type: 'text' })
+//   + injected virtual fields (from bo.virtualFields)
 ```
 
-Translation fields are injected as `kind: 'translation'` with `searchable: true` and `filterable: { type: 'text' }` by default.
+`valueHelps` are picked up directly from `bo.valueHelps` — each entry is a `ViewDef` with a `.vh({ key, display })` annotation (issue #34) — so you don't pass them to `boMeta` explicitly.
 
-## searchWhere
+### `searchWhere(view, query)`
 
-Builds a parameterized OR clause over all `.searchable()` columns:
+Build a parameterised OR clause over every `.searchable()` column in the view:
 
 ```typescript
 import { searchWhere } from '@pgbo/core/metadata'
 
-const result = searchWhere(areaView, 'admin')
-// result.text:   '(slug ILIKE $1)'
-// result.values: ['%admin%']
+const { text, values } = searchWhere(warehouseView, 'main')
+// text:   '(slug ILIKE $1 OR name ILIKE $2)'
+// values: ['%main%', '%main%']
 
-// With multiple searchable columns:
-// result.text:   '(slug ILIKE $1 OR name ILIKE $2)'
-// result.values: ['%admin%', '%admin%']
+const rows = await db.query(`SELECT * FROM warehouse_view WHERE ${text}`, values)
 ```
 
-Use in a raw query or combine with the query builder:
+Returns `{ text: '', values: [] }` when the query is empty or no fields are searchable — safe to inline in a WHERE without guarding.
 
-```typescript
-const { text: searchClause, values: searchValues } = searchWhere(areaView, query)
-if (searchClause) {
-  const rows = await db.query(`SELECT * FROM area_view WHERE ${searchClause}`, searchValues)
-}
-```
+### `filterWhere(view, params)`
 
-## filterWhere
-
-Strips non-filterable keys from user-provided filter params:
+Strip unknown / non-filterable keys from user-provided filter params — guards against arbitrary column filtering via query-string injection:
 
 ```typescript
 import { filterWhere } from '@pgbo/core/metadata'
 
-const safe = filterWhere(areaView, {
-  slug: 'admin',     // filterable → kept
-  sortOrder: 5,      // NOT filterable → stripped
-  unknown: 'x',      // not in view → stripped
+const safe = filterWhere(warehouseView, {
+  slug: 'admin',     // .filterable() → kept
+  sortOrder: 5,      // not filterable → stripped
+  tenantId: 't1',    // not exposed in the view → stripped
 })
-// { slug: 'admin' }
+// → { slug: 'admin' }
 ```
 
-Respects `.filterKey()` overrides — if a column has `.filterKey('otherCol')`, the filter applies to `otherCol`.
+Respects `.filterKey()` overrides — if a column declares `filterKey('statusCode')`, the user-supplied key gets rewritten to the target column before reaching the query.
 
-## enrichItems
+### `enrichItems(db, items, config)`
 
-Batch-resolves translations for a list of items in a single SQL query:
+Batch-load translations for a list of items in a single SQL query — skips per-row joins when you can't shape the query that way:
 
 ```typescript
 import { enrichItems } from '@pgbo/core/metadata'
 
 const enriched = await enrichItems(db, rawItems, {
   translationTable: 'area_translation',
-  parentKey: 'areaId',
-  idField: 'id',
-  fields: ['name'],
+  parentKey: 'areaId',        // FK column on the translation table
+  idField: 'id',              // PK on each item
+  fields: ['name'],           // translation fields to lift onto each item
   locale: 'de',
   fallbackLocale: 'en',
 })
-```
 
-Each item gets:
-- Resolved translation fields (`name`) for the requested locale, with fallback
-- A `translations` array containing all available translations
-
-```typescript
 // enriched[0]:
 // {
 //   ...originalItem,
-//   name: 'Nordzone',              // resolved from 'de' translation
+//   name: 'Nordzone',                      // from 'de' translation
 //   translations: [
 //     { locale: 'de', name: 'Nordzone', areaId: 1 },
 //     { locale: 'en', name: 'North Zone', areaId: 1 },
@@ -146,19 +314,6 @@ Each item gets:
 // }
 ```
 
-## Extended Annotations (R5)
+Falls back to `fallbackLocale` when a requested-locale translation is missing. Attaches the full `translations` array so the UI can show per-locale editors inline.
 
-New annotation methods available on `col()`:
-
-```typescript
-col('slug')
-  .required()                     // marks field as required for create
-  .kind('slug')                   // explicit kind override
-  .filterType('relation')         // explicit filter type
-  .filterOptions([                // for 'select' filter type
-    { value: 'ACTIVE', label: 'Active' },
-    { value: 'ARCHIVED', label: 'Archived' },
-  ])
-  .filterKey('statusCode')        // filter on a different column
-  .quick()                        // show as quick-filter in list header
-```
+For views built with [`.translatedJoin()`](schema#translated-views-—-translatedjoin), you don't need `enrichItems` — the LEFT JOIN resolves translations at query time. Use `enrichItems` when you're composing data the view builder can't express.


### PR DESCRIPTION
## Summary

User requested a massive docs enhancement covering two specific topics: the \`@pgbo/fastify\` adapter and the metadata concept (\"how to fetch etc\"). This PR does both.

## What's new

### 1. \`docs/fastify.md\` (new page, ~340 lines)

First-class reference for the Fastify adapter:
- End-to-end minimal example (schema → BO → projection → server)
- \`registerProjection\` full signature + all 8 config options
- \`registerViewRoute\` for read-only surfaces
- Pagination + list query params table (\`page\`, \`limit\`, \`search\`, \`sort\`, \`order\`, \`filter.*\`, \`locale\`, \`fields\`)
- Tenant scoping + \`includeGlobal\` 403 semantics
- \`afterWrite\` hook
- \`FileResponse\` / binary action results
- \`paginateView\` + \`buildTenantWhere\` helpers
- Value-help endpoint behavior
- \"What routes a projection produces\" reference table
- \"What stays your responsibility\" section (auth, validation, CORS, etc.)

### 2. \`docs/metadata.md\` (rewrite, 164 → 324 lines)

Previous doc was API-only. New doc is a conceptual guide:
- Why metadata exists — the \"declare each field three times\" problem
- Full flow: column annotations → \`viewMeta\` / \`boMeta\` → \`/meta/:name\` → frontend UI
- Fetching metadata (endpoint, \`PublicBoMeta\` response shape)
- \`label\` → \`labelKey\` i18n contract explained
- Field kind inference table + filterable expansion
- \"Driving a list page from metadata\" — concrete frontend code
- \"Driving a form from metadata\" — concrete frontend code
- Value-helps & the relation flow (how \`FilterMeta.endpoint\` wires dropdowns)
- Column narrowing via projections
- Server-side helpers (\`searchWhere\`, \`filterWhere\`, \`enrichItems\`) with when-to-use guidance

### Sidebar

New \`Adapters\` section in the VitePress sidebar pointing at \`@pgbo/fastify\`.

## Test plan

- [x] \`npm run docs:build\` clean — no dead links, no warnings
- [x] New pages land at [\`/pgbo/fastify\`](https://tim-riep.github.io/pgbo/fastify) and [\`/pgbo/metadata\`](https://tim-riep.github.io/pgbo/metadata) after deploy
- [x] Cross-references to \`schema#value-help-views\`, \`schema#translated-views-—-translatedjoin\`, \`metadata#meta-name-response-shape\`, \`fastify#value-help-endpoints\` resolve (anchor ids verified against the built HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)