### PR TITLE
feat(core): column-to-value-help binding via metadata (closes #35)

### DIFF
--- a/.changeset/column-value-help-binding.md
+++ b/.changeset/column-value-help-binding.md
@@ -1,0 +1,30 @@
+---
+"@pgbo/core": minor
+---
+
+Column-to-value-help binding via metadata (closes #35).
+
+`col(...).valueHelp(vhView)` was already accepted, but `boMeta()` didn't surface a top-level reference on the field — frontends had to read `meta.valueHelps` separately, hard-code which column uses which value help, and hand-write the fetch boilerplate.
+
+Two changes:
+
+1. **`FieldMeta.valueHelp`** — `viewMeta` / `boMeta` now emit a `ValueHelpRef` on every field annotated with `.valueHelp(...)`:
+
+```typescript
+{
+  key: 'uomSlug',
+  kind: 'relation',
+  valueHelp: {
+    name: 'uom',                   // BO key (the URL segment Fastify uses)
+    keyField: 'slug',
+    displayField: 'name',
+    endpoint: '/bo/product/valueHelp/uom',  // populated by @pgbo/fastify
+  },
+}
+```
+
+`@pgbo/fastify` resolves `endpoint` against the projection prefix in its `/meta/:name` transform; reading the raw `boMeta(bo)` (no projection context) gives the ref without `endpoint`.
+
+2. **`defineBO()` validation** — every column-level `.valueHelp(vhView)` must reference a view also registered under `valueHelps`. Throws at definition time with a suggestion of known keys instead of letting forms 404 at request time.
+
+Top-level `meta.valueHelps[].name` and `filterable.endpoint` now also use the BO key (the URL segment) instead of the underlying view name — `filterable.endpoint` was previously the view name, which didn't match the actual route URL.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -71,6 +71,7 @@ interface PublicFieldMeta {
   immutable: boolean                            // disable input in the form
   searchable: boolean                           // hits the list `?search=` param
   filterable: false | FilterMeta                // false, or config for the filter widget
+  valueHelp?: ValueHelpRef                      // dropdown source for forms (issue #35)
   inList: boolean                               // column visible in list view (false if hidden)
   inForm: boolean                               // field visible in form view (false if hidden)
   required: boolean
@@ -79,12 +80,58 @@ interface PublicFieldMeta {
 
 interface FilterMeta {
   type: 'text' | 'date' | 'select' | 'relation'
-  endpoint?: string                             // value-help URL for 'relation'/'select'
+  endpoint?: string                             // absolute value-help URL for 'relation'/'select'
   valueField?: string                           // column on the target that holds the id
   labelField?: string                           // column shown to the user
   options?: { value: string; label: string }[]  // static options for 'select'
 }
+
+interface ValueHelpRef {
+  name: string                                  // BO key (the URL segment)
+  endpoint: string                              // e.g. '/bo/product/valueHelp/uom'
+  keyField: string                              // from the vh view's .vh({ key })
+  displayField: string                          // from the vh view's .vh({ display })
+}
 ```
+
+### Column-to-value-help binding (issue #35)
+
+`col(...).valueHelp(vhView)` binds a column to a value-help view. When the BO registers the same view in `valueHelps`, metadata emits a `valueHelp` reference on the field, ready for a metadata-driven form to render the column as a dropdown without per-app wiring:
+
+```typescript
+const uomVh = view('uom_vh').from(uomTable)
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
+
+const productView = view('product_view').from(productTable).columns({
+  sku: col('sku').label('product.sku'),
+  uomSlug: col('uomSlug').label('product.uom').valueHelp(uomVh),
+})
+
+const productBO = defineBO(productView, {
+  paramField: 'id',
+  valueHelps: { uom: uomVh },        // key 'uom' is the URL segment
+})
+```
+
+`/meta/product` returns:
+
+```json
+{
+  "fields": [
+    { "key": "uomSlug", "kind": "relation",
+      "valueHelp": {
+        "name": "uom",
+        "endpoint": "/bo/product/valueHelp/uom",
+        "keyField": "slug",
+        "displayField": "name"
+      }
+    }
+  ]
+}
+```
+
+`defineBO()` validates that every column-level `.valueHelp(vhView)` references a view that's also registered under `valueHelps` — typos and missed wiring throw at definition time, not at request time when the form would otherwise hit a non-existent endpoint.
 
 ### `label` → `labelKey` — the i18n contract
 

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -66,24 +66,35 @@ type PublicBoMeta = Omit<BOMeta, 'fields'> & { readonly fields: readonly PublicF
  * - label → labelKey with `${projectionName}.${key}` fallback
  * - hidden → inList/inForm: false
  * - restricts field list to the projection's column allowlist if set
+ * - resolves valueHelp / filterable.endpoint to absolute URLs (issue #35)
  */
 function transformProjectionMeta(projection: ProjectionDef, meta: BOMeta): PublicBoMeta {
   const allowed = projection.columns ? new Set(projection.columns) : undefined
+  const vhPrefix = `/bo/${projection.name}/valueHelp`
   const fields = meta.fields
     .filter(f => !allowed || allowed.has(f.key))
-    .map((f): PublicFieldMeta => ({
-      key: f.key,
-      kind: f.kind,
-      labelKey: f.label ?? `${projection.name}.${f.key}`,
-      hidden: f.hidden,
-      immutable: f.immutable,
-      searchable: f.searchable,
-      filterable: f.filterable,
-      inList: f.hidden ? false : f.inList,
-      inForm: f.hidden ? false : f.inForm,
-      required: f.required,
-      quick: f.quick,
-    }))
+    .map((f): PublicFieldMeta => {
+      const valueHelp = f.valueHelp
+        ? { ...f.valueHelp, endpoint: `${vhPrefix}/${f.valueHelp.name}` }
+        : undefined
+      const filterable = f.filterable && typeof f.filterable === 'object' && f.filterable.endpoint
+        ? { ...f.filterable, endpoint: `${vhPrefix}/${f.filterable.endpoint}` }
+        : f.filterable
+      return {
+        key: f.key,
+        kind: f.kind,
+        labelKey: f.label ?? `${projection.name}.${f.key}`,
+        hidden: f.hidden,
+        immutable: f.immutable,
+        searchable: f.searchable,
+        filterable,
+        valueHelp,
+        inList: f.hidden ? false : f.inList,
+        inForm: f.hidden ? false : f.inForm,
+        required: f.required,
+        quick: f.quick,
+      }
+    })
   return { ...meta, name: projection.name, fields }
 }
 

--- a/packages/pgbo-fastify/tests/value-help-binding.test.ts
+++ b/packages/pgbo-fastify/tests/value-help-binding.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify from 'fastify'
+import { table, view, text, integer, col } from '@pgbo/core/schema'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
+import { registerProjection } from '../src/index.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const productTable = table('product', {
+  columns: {
+    id: integer().notNull(),
+    sku: text().notNull(),
+    uomSlug: text().notNull(),
+  },
+  primaryKey: ['id'],
+})
+
+const uomTable = table('uom', {
+  columns: { slug: text().notNull(), name: text().notNull() },
+  primaryKey: ['slug'],
+})
+
+// vh-annotated view used as the dropdown source
+const uomVh = view('uom_vh').from(uomTable)
+  .columns({ slug: col('slug'), name: col('name') })
+  .vh({ key: 'slug', display: 'name' })
+
+const productView = view('product_view').from(productTable).columns({
+  id: col('id'),
+  sku: col('sku'),
+  uomSlug: col('uomSlug').valueHelp(uomVh),  // <-- column-to-vh binding (issue #35)
+})
+
+const productBO = defineBO(productView, {
+  paramField: 'id',
+  // BO registers the same vh under key "uom" — the URL segment Fastify uses
+  valueHelps: { uom: uomVh },
+})
+
+const productProjection = defineProjection(productBO, {
+  name: 'product',
+  actions: { read: true },
+})
+
+describe('Column-to-value-help binding via metadata (issue #35)', () => {
+  let testDb: TestDatabase
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [productTable, uomTable],
+      seed: [
+        `CREATE OR REPLACE VIEW product_view AS SELECT id, sku, uom_slug FROM product`,
+        `CREATE OR REPLACE VIEW uom_vh AS SELECT slug, name FROM uom`,
+        `INSERT INTO uom (slug, name) VALUES ('kg', 'Kilogram'), ('m', 'Meter')`,
+        `INSERT INTO product (id, sku, uom_slug) VALUES (1, 'X', 'kg')`,
+      ],
+    })
+  })
+
+  afterAll(async () => { await testDb.dispose() })
+
+  it('exposes field.valueHelp with absolute endpoint URL', async () => {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: productProjection,
+      view: productView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/meta/product' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    const uomField = body.fields.find((f: any) => f.key === 'uomSlug')
+    expect(uomField.valueHelp).toEqual({
+      name: 'uom',
+      keyField: 'slug',
+      displayField: 'name',
+      endpoint: '/bo/product/valueHelp/uom',
+    })
+    await app.close()
+  })
+
+  it('the endpoint URL actually serves the value-help dropdown', async () => {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: productProjection,
+      view: productView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+
+    const metaRes = await app.inject({ method: 'GET', url: '/meta/product' })
+    const uomEndpoint = metaRes.json().fields.find((f: any) => f.key === 'uomSlug').valueHelp.endpoint
+
+    const vhRes = await app.inject({ method: 'GET', url: uomEndpoint })
+    expect(vhRes.statusCode).toBe(200)
+    const items = vhRes.json().items
+    expect(items.find((r: any) => r.slug === 'kg')).toEqual({ slug: 'kg', name: 'Kilogram' })
+    await app.close()
+  })
+
+  it('field.valueHelp is undefined for columns without .valueHelp()', async () => {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: productProjection,
+      view: productView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/meta/product' })
+    const skuField = res.json().fields.find((f: any) => f.key === 'sku')
+    expect(skuField.valueHelp).toBeUndefined()
+    await app.close()
+  })
+})

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -52,13 +52,35 @@ export function defineBO<
   // Value helps must be views annotated with .vh() — surface a clear error instead
   // of letting Fastify fail at request time when it can't find key/display columns.
   const valueHelps = config.valueHelps ?? {}
+  const boName = config.name ?? snakeToCamel(root.name)
   for (const [vhName, vhView] of Object.entries(valueHelps)) {
     if (!vhView.vhAnnotation) {
-      const boName = config.name ?? snakeToCamel(root.name)
       throw new Error(
         `BO "${boName}": valueHelps["${vhName}"] points to view "${vhView.name}" which has no .vh({ key, display }) annotation. ` +
         `Mark it as a value help with .vh({ key: '…', display: '…' }) on the view.`,
       )
+    }
+  }
+
+  // Cross-check: every column-level `.valueHelp(vhView)` on the root must reference
+  // a vh view that's also registered in the BO's `valueHelps` (issue #35). Catches
+  // typos and missed wiring at definition time instead of at request time when the
+  // form tries to fetch a non-existent endpoint.
+  if ('selectedColumns' in root && root.selectedColumns) {
+    const registeredViews = new Set(Object.values(valueHelps))
+    for (const [colKey, entry] of Object.entries(root.selectedColumns)) {
+      const vh = (entry as { annotations?: { valueHelp?: ViewDef } }).annotations?.valueHelp
+      if (vh && !registeredViews.has(vh)) {
+        const known = Object.keys(valueHelps)
+        const suggestion = known.length > 0
+          ? ` Known value helps: ${known.map(k => `"${k}"`).join(', ')}.`
+          : ' No value helps registered on this BO.'
+        throw new Error(
+          `BO "${boName}": column "${colKey}" references value help view "${vh.name}" via .valueHelp(...), ` +
+          `but no entry in this BO's valueHelps points at that view.${suggestion} ` +
+          `Add it under valueHelps so the metadata-driven form can resolve the dropdown.`,
+        )
+      }
     }
   }
 

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -21,9 +21,9 @@ import { isTranslatedRef } from '../schema/i18n.js'
 import { toSnakeCase } from '../schema/table.js'
 import { toCamelCase } from '../query/select.js'
 import { getI18nConfig } from '../schema/i18n.js'
-import type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig } from './types.js'
+import type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig, ValueHelpRef } from './types.js'
 
-export type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig } from './types.js'
+export type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig, ValueHelpRef } from './types.js'
 
 // --- Kind inference ---
 
@@ -77,6 +77,15 @@ function inferFilterMeta(kind: FieldKind, annotations: {
   }
 }
 
+/** Look up the ViewDef referenced by `.valueHelp(...)` on a column with the given output key. */
+function findColumnValueHelpView(source: ViewDef | TableDef, fieldKey: string): ViewDef | undefined {
+  if (!isViewDef(source)) return undefined
+  const cols = source.selectedColumns
+  if (!cols) return undefined
+  const entry = cols[fieldKey] as { annotations?: { valueHelp?: ViewDef } } | undefined
+  return entry?.annotations?.valueHelp
+}
+
 function buildFieldMeta(
   key: string,
   annotations: ColumnRef['annotations'],
@@ -91,6 +100,14 @@ function buildFieldMeta(
     ? inferFilterMeta(kind, annotations)
     : false
 
+  // Surface the column-to-vh binding (issue #35) so metadata-driven forms can
+  // render dropdowns automatically. `name` is set to the view name as a stand-in;
+  // boMeta() rewrites it to the BO's `valueHelps` key (the URL segment Fastify uses).
+  const vh = annotations.valueHelp
+  const valueHelp: ValueHelpRef | undefined = vh?.vhAnnotation
+    ? { name: vh.name, keyField: vh.vhAnnotation.key, displayField: vh.vhAnnotation.display }
+    : undefined
+
   return {
     key,
     kind,
@@ -99,6 +116,7 @@ function buildFieldMeta(
     immutable: annotations.immutable ?? false,
     searchable: annotations.searchable ?? false,
     filterable,
+    valueHelp,
     inList: annotations.inList ?? true,
     inForm: annotations.inForm ?? true,
     required: annotations.required ?? false,
@@ -151,7 +169,33 @@ export function boMeta(
 ): BOMeta {
   const base = viewMeta(bo.root)
 
-  const fields = [...base.fields]
+  // Build a lookup so per-field valueHelp refs can use the BO's `valueHelps` key
+  // (the URL segment Fastify routes use) instead of the underlying view name.
+  // Same map drives `filterable.endpoint` rewriting below.
+  const vhKeyByView = new Map<unknown, string>()
+  for (const [vhKey, vhView] of Object.entries(bo.valueHelps)) {
+    vhKeyByView.set(vhView, vhKey)
+  }
+
+  const fields = base.fields.map(f => {
+    let next = f
+    if (f.valueHelp) {
+      // viewMeta sets valueHelp.name = view name; rewrite to BO key when it matches
+      const annotatedView = findColumnValueHelpView(bo.root, f.key)
+      const boKey = annotatedView ? vhKeyByView.get(annotatedView) : undefined
+      if (boKey && boKey !== f.valueHelp.name) {
+        next = { ...next, valueHelp: { ...f.valueHelp, name: boKey } }
+      }
+    }
+    if (next.filterable && typeof next.filterable === 'object' && next.filterable.endpoint) {
+      const annotatedView = findColumnValueHelpView(bo.root, f.key)
+      const boKey = annotatedView ? vhKeyByView.get(annotatedView) : undefined
+      if (boKey && boKey !== next.filterable.endpoint) {
+        next = { ...next, filterable: { ...next.filterable, endpoint: boKey } }
+      }
+    }
+    return next
+  })
 
   // Inject translation fields
   if (config?.translations) {
@@ -221,9 +265,11 @@ export function boMeta(
     }
   })
 
-  // Build valueHelps from the BO's registered views (each is a ViewDef with .vh())
-  const valueHelps = Object.entries(bo.valueHelps).map(([, vhView]) => ({
-    name: vhView.name,
+  // Build valueHelps from the BO's registered views (each is a ViewDef with .vh()).
+  // `name` is the BO key — that's the URL segment Fastify routes use, and what
+  // FieldMeta.valueHelp.name and filterable.endpoint reference (issue #35).
+  const valueHelps = Object.entries(bo.valueHelps).map(([boKey, vhView]) => ({
+    name: boKey,
     fields: viewMeta(vhView).fields,
   }))
 

--- a/packages/pgbo/src/metadata/types.ts
+++ b/packages/pgbo/src/metadata/types.ts
@@ -10,6 +10,30 @@ export interface FilterMeta {
   readonly options?: readonly FilterOption[]
 }
 
+/**
+ * Reference from a field to a value-help endpoint (issue #35). Set when a column
+ * is annotated with `.valueHelp(vhView)` and the surrounding BO registers that
+ * view in `valueHelps`. Lets metadata-driven forms render the field as a dropdown
+ * without per-app wiring.
+ */
+export interface ValueHelpRef {
+  /**
+   * Key under `bo.valueHelps` — the URL segment Fastify uses for the route.
+   * Same value is used for the metadata's top-level `valueHelps[].name`.
+   */
+  readonly name: string
+  /** Column on the value-help view that holds the identifier (`.vh({ key })`). */
+  readonly keyField: string
+  /** Column on the value-help view that holds the human-readable label (`.vh({ display })`). */
+  readonly displayField: string
+  /**
+   * Full HTTP path. Populated by `@pgbo/fastify`'s projection-aware transform
+   * (`/bo/{projection.name}/valueHelp/{name}`); undefined when reading the raw
+   * `boMeta()` output without projection context.
+   */
+  readonly endpoint?: string
+}
+
 export interface FieldMeta {
   readonly key: string
   readonly kind: FieldKind
@@ -18,6 +42,7 @@ export interface FieldMeta {
   readonly immutable: boolean
   readonly searchable: boolean
   readonly filterable: false | FilterMeta
+  readonly valueHelp?: ValueHelpRef
   readonly inList: boolean
   readonly inForm: boolean
   readonly required: boolean

--- a/packages/pgbo/tests/metadata/metadata.test.ts
+++ b/packages/pgbo/tests/metadata/metadata.test.ts
@@ -86,6 +86,7 @@ describe('Metadata: viewMeta (R1)', () => {
     const createdField = meta.fields.find(f => f.key === 'createdAt')!
     expect(createdField.filterable).toEqual({ type: 'date' })
 
+    // viewMeta has no BO context → endpoint name falls back to the view name
     const whField = meta.fields.find(f => f.key === 'warehouseSlug')!
     expect(whField.filterable).toEqual({
       type: 'relation',
@@ -94,6 +95,23 @@ describe('Metadata: viewMeta (R1)', () => {
       labelField: 'name',
     })
     expect(whField.quick).toBe(true)
+  })
+
+  it('surfaces FieldMeta.valueHelp for columns annotated with .valueHelp(vhView) (issue #35)', () => {
+    const meta = viewMeta(areaView)
+    const whField = meta.fields.find(f => f.key === 'warehouseSlug')!
+    expect(whField.valueHelp).toEqual({
+      // viewMeta has no BO context → name falls back to view name; boMeta rewrites to BO key
+      name: 'warehouse_vh',
+      keyField: 'slug',
+      displayField: 'name',
+    })
+  })
+
+  it('FieldMeta.valueHelp is undefined for columns without .valueHelp()', () => {
+    const meta = viewMeta(areaView)
+    expect(meta.fields.find(f => f.key === 'slug')!.valueHelp).toBeUndefined()
+    expect(meta.fields.find(f => f.key === 'sortOrder')!.valueHelp).toBeUndefined()
   })
 
   it('handles translated columns as kind: translation', () => {
@@ -146,6 +164,74 @@ describe('Metadata: boMeta (R2)', () => {
     const readOnlyBO = defineBO(areaTable, {})
     const meta = boMeta(readOnlyBO)
     expect(meta.readOnly).toBe(true)
+  })
+
+  it('rewrites field.valueHelp.name + filterable.endpoint to the BO key (issue #35)', () => {
+    const areaBO = defineBO(areaView, {
+      paramField: 'id',
+      // BO registers the same vh view under key "warehouse" (the URL segment)
+      valueHelps: { warehouse: warehouseVH },
+    })
+    const meta = boMeta(areaBO)
+
+    const wh = meta.fields.find(f => f.key === 'warehouseSlug')!
+    // Before boMeta: viewMeta emitted `warehouse_vh` (view name) — boMeta rewrites both
+    expect(wh.valueHelp).toEqual({
+      name: 'warehouse',           // BO key, matches /bo/.../valueHelp/warehouse
+      keyField: 'slug',
+      displayField: 'name',
+    })
+    expect(wh.filterable).toEqual({
+      type: 'relation',
+      endpoint: 'warehouse',
+      valueField: 'slug',
+      labelField: 'name',
+    })
+
+    // valueHelps top-level entry also uses the BO key
+    expect(meta.valueHelps.find(v => v.name === 'warehouse')).toBeDefined()
+  })
+})
+
+describe('defineBO column-to-vh validation (issue #35)', () => {
+  it('throws when a column references a vh view that is not registered on the BO', () => {
+    const someVh = view('some_vh').from(areaTable)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
+    const otherVh = view('other_vh').from(areaTable)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
+
+    const v = view('bad_view').from(areaTable).columns({
+      id: col('id'),
+      // .valueHelp(someVh) — but the BO only registers `otherVh` under `other`
+      target: col('slug').valueHelp(someVh),
+    })
+
+    expect(() =>
+      defineBO(v, { paramField: 'id', valueHelps: { other: otherVh } }),
+    ).toThrow(/references value help view "some_vh".*Known value helps: "other"/)
+  })
+
+  it('throws with no-value-helps suggestion when the BO has none registered', () => {
+    const someVh = view('some_vh').from(areaTable)
+      .columns({ slug: col('slug'), name: col('name') })
+      .vh({ key: 'slug', display: 'name' })
+    const v = view('bad_view').from(areaTable).columns({
+      id: col('id'),
+      target: col('slug').valueHelp(someVh),
+    })
+    expect(() => defineBO(v, { paramField: 'id' })).toThrow(/No value helps registered on this BO/)
+  })
+
+  it('passes when every column-level vh is also in valueHelps', () => {
+    const v = view('ok_view').from(areaTable).columns({
+      id: col('id'),
+      warehouseSlug: col('slug').valueHelp(warehouseVH),
+    })
+    expect(() =>
+      defineBO(v, { paramField: 'id', valueHelps: { warehouse: warehouseVH } }),
+    ).not.toThrow()
   })
 })
 


### PR DESCRIPTION
## Summary

Surfaces \`col(...).valueHelp(vhView)\` on each \`FieldMeta\` as a \`ValueHelpRef\` so metadata-driven forms can render the column as a dropdown without per-app wiring.

## API

```typescript
const uomVh = view('uom_vh').from(uomTable)
  .columns({ slug: col('slug'), name: col('name') })
  .vh({ key: 'slug', display: 'name' })

const productView = view('product_view').from(productTable).columns({
  uomSlug: col('uomSlug').label('product.uom').valueHelp(uomVh),
})

const productBO = defineBO(productView, {
  paramField: 'id',
  valueHelps: { uom: uomVh },        // 'uom' is the URL segment
})
```

\`GET /meta/product\` →

\`\`\`json
{
  "fields": [
    { "key": "uomSlug", "kind": "relation",
      "valueHelp": {
        "name": "uom",
        "endpoint": "/bo/product/valueHelp/uom",
        "keyField": "slug",
        "displayField": "name"
      }
    }
  ]
}
\`\`\`

## Three pieces

1. **\`FieldMeta.valueHelp\`** — \`viewMeta\` emits the ref using the view name as a stand-in; \`boMeta\` rewrites it to the BO's \`valueHelps\` key (the URL segment Fastify routes use).
2. **\`defineBO()\` validation** — every column-level \`.valueHelp(vhView)\` must reference a view also registered under \`valueHelps\`. Mismatches throw at definition time with a suggestion of known keys, instead of letting forms 404 at request time.
3. **\`@pgbo/fastify\` \`/meta/:name\` transform** resolves \`valueHelp.endpoint\` (and \`filterable.endpoint\`) to absolute URLs. Reading raw \`boMeta(bo)\` without projection context returns the ref without \`endpoint\`.

## Bug fixes folded in

- Top-level \`meta.valueHelps[].name\` now uses the BO key (was the view name, which didn't match the actual route URL).
- \`filterable.endpoint\` now uses the BO key (same bug).

These are technically breaking but only matter to consumers reading metadata — and the previous values pointed at non-existent URLs, so it's a fix.

## Test plan

- [x] New unit tests in \`metadata.test.ts\`: viewMeta emits valueHelp; boMeta rewrites name + endpoint to BO key; defineBO throws on missing/mismatched bindings; happy path passes
- [x] New integration test in \`value-help-binding.test.ts\` (Fastify): \`/meta/{name}\` returns absolute URLs; the URL actually serves the dropdown
- [x] All 458 tests pass (399 core + 59 fastify), lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)