### PR TITLE
feat(fastify): auto-wrap routes with db.withContext when sessionParams configured (closes #42)

### DIFF
--- a/.changeset/auto-withcontext.md
+++ b/.changeset/auto-withcontext.md
@@ -1,0 +1,22 @@
+---
+"@pgbo/core": minor
+"@pgbo/fastify": minor
+---
+
+Auto-wrap Fastify routes with `db.withContext` when sessionParams are configured (closes #42).
+
+Views with `.translatedJoin()` rely on `current_setting('app.locale', true)` to filter by locale. Until now, hitting one through `registerProjection` always returned the fallback locale because the route never called `db.withContext` to emit the per-request `SET LOCAL`. Now every read handler is wrapped automatically when `sessionParams` is configured:
+
+- `GET {prefix}` (list), `GET {prefix}/:param` (detail), value-help routes, and `registerViewRoute` reads — wrapped
+- `PUT` / `DELETE` — the projection-visibility pre-fetch is wrapped (so projection scope sees the locale); the actual write runs unwrapped
+- `POST` / custom actions — unwrapped (writes don't depend on `current_setting`; locale-aware custom actions call `db.withContext` inside the handler)
+
+When no `sessionParams` are configured, the wrap is a no-op — apps without them don't pay an extra transaction per request.
+
+### New API
+
+- `Database.hasSessionParams: boolean` — true when `DatabaseConfig.sessionParams` was set with at least one resolver. The Fastify adapter reads this to decide whether to wrap.
+
+### Internal type widening (compatible)
+
+`paginateView`, `enrichCompositions`, `enrichAssociations`, and the new `DbOrTx` exported from `@pgbo/fastify` accept `Database | TransactionClient`. Existing consumers passing `Database` still work — only callers that need to receive a scoped tx benefit from the widening.

--- a/docs/fastify.md
+++ b/docs/fastify.md
@@ -435,6 +435,36 @@ registerProjection(app, db, {
 
 `enabled: false` falls back to the pre-#38 behaviour: routes registered without any `schema` block. Use it when you want full control over the OpenAPI spec, or when you don't need it at all.
 
+## Session params + `db.withContext` — automatic
+
+When `createDatabase({ sessionParams })` is configured, `registerProjection` and `registerViewRoute` automatically wrap every read handler in `db.withContext(ctx, ...)` so views with `.translatedJoin()` (or any `current_setting('…', true)` lookup) see the per-request values without per-route boilerplate.
+
+```typescript
+const db = createDatabase({
+  connectionString,
+  sessionParams: { 'app.locale': (ctx) => (ctx as RouteContext).locale },
+})
+
+registerProjection(app, db, {
+  projection: warehouseProjection,
+  extractContext: (req) => ({ app, db, locale: req.headers['accept-language'] ?? 'en' }),
+})
+
+// Hitting /bo/warehouse/valueHelp/uom now resolves the translation for the
+// caller's locale — no extra wiring on the route.
+```
+
+Scope of the wrap:
+
+- `GET {prefix}` (list) — wrapped
+- `GET {prefix}/:param` (detail) — wrapped
+- `GET /bo/{name}/valueHelp/{vh}` — wrapped
+- `PUT` / `DELETE` — the projection-visibility row pre-fetch is wrapped; the actual `bo.update` / `bo.delete` call runs unwrapped because writes don't depend on `current_setting`.
+- `POST` / custom actions — unwrapped. If your custom action handler does locale-aware reads, call `db.withContext(ctx, ...)` inside the handler explicitly.
+- View routes (`registerViewRoute`) — wrapped.
+
+When `sessionParams` is empty (`db.hasSessionParams === false`), the wrap is a no-op — apps without session params don't pay an extra transaction round-trip per request.
+
 ## What stays your responsibility
 
 - **Auth**: `extractContext` is where you parse JWTs / session cookies / headers. The adapter never invents a `userId` or `tenantId`.

--- a/packages/pgbo-fastify/src/helpers.ts
+++ b/packages/pgbo-fastify/src/helpers.ts
@@ -2,11 +2,19 @@
 
 import type { Database } from '@pgbo/core'
 import type { ViewDef } from '@pgbo/core/schema'
-import type { PaginatedResult, ListParams, WhereConditions } from '@pgbo/core/query'
+import type { PaginatedResult, ListParams, WhereConditions, TransactionClient } from '@pgbo/core/query'
 import { viewMeta } from '@pgbo/core/metadata'
 
+/**
+ * Either the top-level `Database` or a request-scoped `TransactionClient` from
+ * `db.withContext(...)`. Both share the `from` / `_table` / `query` surface that
+ * paginateView and friends rely on, so accepting both lets routes opt into the
+ * session-param-aware scope without changing helper code (issue #42).
+ */
+export type DbOrTx = Database | TransactionClient
+
 export interface PaginateOptions {
-  readonly db: Database
+  readonly db: DbOrTx
   readonly view: ViewDef
   readonly params: ListParams
   readonly baseWhere?: WhereConditions

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -7,11 +7,11 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import type { Database } from '@pgbo/core'
 import type { ViewDef } from '@pgbo/core/schema'
-import type { WhereConditions } from '@pgbo/core/query'
+import type { WhereConditions, TransactionClient } from '@pgbo/core/query'
 import { parseListParams } from '@pgbo/core/query'
 import { boMeta, viewMeta, type BOMeta, type FieldMeta } from '@pgbo/core/metadata'
 import { enrichCompositions, enrichAssociations, projectRow, projectionExposes, type ProjectionDef } from '@pgbo/core/bo'
-import type { ProjectionRouteConfig, ViewRouteConfig, FileResponse, SwaggerConfig } from './types.js'
+import type { ProjectionRouteConfig, ViewRouteConfig, FileResponse, SwaggerConfig, RouteContext } from './types.js'
 import { paginateView, buildTenantWhere } from './helpers.js'
 import {
   rowSchema, listResponseSchema, listQuerystringSchema, paramSchema, paramFieldType,
@@ -149,6 +149,24 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
 
   const readExposed = projectionExposes(projection, 'read')
 
+  // --- Session-param wrap (issue #42) ---
+  // When the database has sessionParams configured, every read handler runs
+  // inside `db.withContext(ctx, ...)` so views with .translatedJoin() (or any
+  // current_setting() lookup) see the per-request values. The handler receives
+  // the scoped TransactionClient, which paginateView/enrichCompositions/etc.
+  // accept (their `db` params widened to Database | TransactionClient).
+  // When sessionParams is empty, the wrap is a no-op — saves an extra
+  // transaction round-trip per request.
+  function withSession<T>(
+    ctx: RouteContext,
+    fn: (q: Database | TransactionClient) => Promise<T>,
+  ): Promise<T> {
+    if (db.hasSessionParams) {
+      return db.withContext(ctx as unknown as Record<string, unknown>, tx => fn(tx))
+    }
+    return fn(db)
+  }
+
   // --- OpenAPI schema generation (issue #38) ---
   const swagger: SwaggerConfig = config.swagger ?? {}
   const swaggerEnabled = swagger.enabled !== false  // default on
@@ -179,8 +197,12 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
 
   // Fetch a single row by paramField — used by detail + write-protection.
   // Applies the projection's root WHERE so "invisible" rows 404 even if they exist.
-  async function fetchByParam(paramValue: string, userId?: string): Promise<Record<string, unknown> | undefined> {
-    let q = db.from(viewDef).where(mergeWhere({ [paramField]: paramValue } as WhereConditions, projection.where) ?? { [paramField]: paramValue } as WhereConditions)
+  async function fetchByParam(
+    queryable: Database | TransactionClient,
+    paramValue: string,
+    userId?: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    let q = queryable.from(viewDef).where(mergeWhere({ [paramField]: paramValue } as WhereConditions, projection.where) ?? { [paramField]: paramValue } as WhereConditions)
     if (userId) q = q.as(userId)
     const rows = await q.execute()
     return rows[0] as Record<string, unknown> | undefined
@@ -217,24 +239,26 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
         : undefined
       const baseWhere = mergeWhere(tenantWhere, projection.where)
 
-      const result = await paginateView({
-        db, view: viewDef, params, baseWhere, userId: ctx.userId,
+      return withSession(ctx, async (q) => {
+        const result = await paginateView({
+          db: q, view: viewDef, params, baseWhere, userId: ctx.userId,
+        })
+
+        let items = result.items as Record<string, unknown>[]
+        if (Object.keys(bo.compositions).length > 0) {
+          items = await enrichCompositions(q, bo, items, { ctx: { ...ctx } })
+        }
+        if (Object.keys(bo.associations).length > 0) {
+          items = await enrichAssociations(q, bo, items, { ctx: { ...ctx } })
+        }
+        if (bo.transformItems) {
+          items = await bo.transformItems(items, ctx.locale, q)
+        }
+        if (includeGlobal) items = attachGlobalFlag(items, tenantCol)
+        items = narrowAll(items)
+
+        return { items, total: result.total, page: result.page, limit: result.limit }
       })
-
-      let items = result.items as Record<string, unknown>[]
-      if (Object.keys(bo.compositions).length > 0) {
-        items = await enrichCompositions(db, bo, items, { ctx: { ...ctx } })
-      }
-      if (Object.keys(bo.associations).length > 0) {
-        items = await enrichAssociations(db, bo, items, { ctx: { ...ctx } })
-      }
-      if (bo.transformItems) {
-        items = await bo.transformItems(items, ctx.locale, db)
-      }
-      if (includeGlobal) items = attachGlobalFlag(items, tenantCol)
-      items = narrowAll(items)
-
-      return { items, total: result.total, page: result.page, limit: result.limit }
     })
 
     app.get(`${prefix}/:param`, withSchema({
@@ -247,26 +271,28 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
       const ctx = await config.extractContext(req)
       const paramValue = extractParam(req)
 
-      const row = await fetchByParam(paramValue, ctx.userId)
-      if (!row) {
-        reply.code(404)
-        return { error: 'Not found' }
-      }
+      return withSession(ctx, async (q) => {
+        const row = await fetchByParam(q, paramValue, ctx.userId)
+        if (!row) {
+          reply.code(404)
+          return { error: 'Not found' }
+        }
 
-      let items: Record<string, unknown>[] = [row]
-      if (Object.keys(bo.compositions).length > 0) {
-        items = await enrichCompositions(db, bo, items, { ctx: { ...ctx } })
-      }
-      if (Object.keys(bo.associations).length > 0) {
-        items = await enrichAssociations(db, bo, items, { ctx: { ...ctx } })
-      }
-      if (bo.transformItems) {
-        items = await bo.transformItems(items, ctx.locale, db)
-      }
-      if (includeGlobal) items = attachGlobalFlag(items, tenantCol)
-      items = narrowAll(items)
+        let items: Record<string, unknown>[] = [row]
+        if (Object.keys(bo.compositions).length > 0) {
+          items = await enrichCompositions(q, bo, items, { ctx: { ...ctx } })
+        }
+        if (Object.keys(bo.associations).length > 0) {
+          items = await enrichAssociations(q, bo, items, { ctx: { ...ctx } })
+        }
+        if (bo.transformItems) {
+          items = await bo.transformItems(items, ctx.locale, q)
+        }
+        if (includeGlobal) items = attachGlobalFlag(items, tenantCol)
+        items = narrowAll(items)
 
-      return items[0]
+        return items[0]
+      })
     })
 
     // Metadata — reflects the narrowed surface. Lives in a separate `/meta/` namespace
@@ -294,8 +320,10 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
         }), async (req: FastifyRequest) => {
           const ctx = await config.extractContext(req)
           const params = parseListParams(req.query as Record<string, unknown>)
-          const result = await paginateView({ db, view: vh, params, userId: ctx.userId })
-          return { items: result.items, total: result.total, page: result.page, limit: result.limit }
+          return withSession(ctx, async (q) => {
+            const result = await paginateView({ db: q, view: vh, params, userId: ctx.userId })
+            return { items: result.items, total: result.total, page: result.page, limit: result.limit }
+          })
         })
       }
     }
@@ -337,7 +365,7 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
       const paramValue = extractParam(req)
 
       // Always resolve the existing row through the projection — out-of-scope records 404
-      const existing = await fetchByParam(paramValue, ctx.userId)
+      const existing = await withSession(ctx, q => fetchByParam(q, paramValue, ctx.userId))
       if (!existing) {
         reply.code(404)
         return { error: 'Not found' }
@@ -363,7 +391,7 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
       const ctx = await config.extractContext(req)
       const paramValue = extractParam(req)
 
-      const existing = await fetchByParam(paramValue, ctx.userId)
+      const existing = await withSession(ctx, q => fetchByParam(q, paramValue, ctx.userId))
       if (!existing) {
         reply.code(404)
         return { error: 'Not found' }
@@ -433,15 +461,26 @@ export function registerViewRoute(app: FastifyInstance, db: Database, config: Vi
       }) }
     : {}
 
+  function viewWithSession<T>(
+    ctx: RouteContext,
+    fn: (q: Database | TransactionClient) => Promise<T>,
+  ): Promise<T> {
+    if (db.hasSessionParams) {
+      return db.withContext(ctx as unknown as Record<string, unknown>, tx => fn(tx))
+    }
+    return fn(db)
+  }
+
   app.get(prefix, listOpts, async (req: FastifyRequest) => {
     const ctx = await config.extractContext(req)
     const params = parseListParams(req.query as Record<string, unknown>)
 
-    const result = await paginateView({
-      db, view: viewDef, params, userId: ctx.userId,
+    return viewWithSession(ctx, async (q) => {
+      const result = await paginateView({
+        db: q, view: viewDef, params, userId: ctx.userId,
+      })
+      return { items: result.items, total: result.total, page: result.page, limit: result.limit }
     })
-
-    return { items: result.items, total: result.total, page: result.page, limit: result.limit }
   })
 
   // GET metadata

--- a/packages/pgbo-fastify/tests/auto-withcontext.test.ts
+++ b/packages/pgbo-fastify/tests/auto-withcontext.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify from 'fastify'
+import { table, view, text, integer, col } from '@pgbo/core/schema'
+import { foreignKey } from '@pgbo/core/schema'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+import { createDatabase } from '@pgbo/core'
+import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
+import { registerProjection } from '../src/index.js'
+import type { RouteContext } from '../src/index.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const uomTable = table('uom', {
+  columns: { slug: text().notNull() },
+  primaryKey: ['slug'],
+})
+
+const uomTranslationTable = table('uom_translation', {
+  columns: {
+    uomSlug: text().notNull(),
+    locale: text().notNull(),
+    name: text().notNull(),
+  },
+  primaryKey: ['uomSlug', 'locale'],
+  foreignKeys: [foreignKey(['uomSlug']).references('uom', ['slug']).onDelete('CASCADE')],
+})
+
+// translatedJoin view — relies on current_setting('app.locale', true)
+const uomVh = view('uom_vh').from(uomTable)
+  .translatedJoin(uomTranslationTable, {
+    parentKey: 'uomSlug',
+    localeColumn: 'locale',
+    localeParam: 'app.locale',
+    fallbackLocale: 'en',
+    fields: ['name'],
+  })
+  .vh({ key: 'slug', display: 'name' })
+
+const productTable = table('product', {
+  columns: {
+    id: integer().notNull(),
+    sku: text().notNull(),
+  },
+  primaryKey: ['id'],
+})
+const productView = view('product_view').from(productTable).columns({
+  id: col('id'),
+  sku: col('sku'),
+})
+const productBO = defineBO(productView, {
+  paramField: 'id',
+  valueHelps: { uom: uomVh },
+})
+const productProjection = defineProjection(productBO, {
+  name: 'product',
+  actions: { read: true },
+})
+
+describe('Auto-wrap Fastify routes with db.withContext (issue #42)', () => {
+  let testDb: TestDatabase
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [uomTable, uomTranslationTable, productTable],
+      seed: [
+        `CREATE OR REPLACE VIEW product_view AS SELECT id, sku FROM product`,
+        `CREATE VIEW uom_vh AS
+          SELECT uom.slug, COALESCE(t_req.name, t_fb.name) AS name
+          FROM uom
+          LEFT JOIN uom_translation t_req ON t_req.uom_slug = uom.slug AND t_req.locale = current_setting('app.locale', true)
+          LEFT JOIN uom_translation t_fb ON t_fb.uom_slug = uom.slug AND t_fb.locale = 'en'`,
+        `INSERT INTO uom (slug) VALUES ('kg'), ('m')`,
+        `INSERT INTO uom_translation (uom_slug, locale, name) VALUES
+          ('kg', 'en', 'Kilogram'), ('kg', 'de', 'Kilogramm'),
+          ('m', 'en', 'Meter'), ('m', 'de', 'Meter (DE)')`,
+      ],
+    })
+  })
+
+  afterAll(async () => { await testDb.dispose() })
+
+  it('serves the requested locale through the value-help endpoint when sessionParams is configured', async () => {
+    // Re-create the database client with sessionParams pointing at ctx.locale
+    const db = createDatabase({
+      connectionString: testDb.connectionString,
+      sessionParams: { 'app.locale': (ctx) => (ctx as RouteContext).locale },
+    })
+    expect(db.hasSessionParams).toBe(true)
+
+    const app = Fastify()
+    let currentLocale = 'de'
+    registerProjection(app, db, {
+      projection: productProjection,
+      view: productView,
+      extractContext: () => ({ app, db, locale: currentLocale }),
+    })
+
+    const deRes = await app.inject({ method: 'GET', url: '/bo/product/valueHelp/uom' })
+    const deNames = (deRes.json().items as { slug: string; name: string }[])
+      .reduce<Record<string, string>>((acc, r) => { acc[r.slug] = r.name; return acc }, {})
+    expect(deNames).toEqual({ kg: 'Kilogramm', m: 'Meter (DE)' })
+
+    currentLocale = 'en'
+    const enRes = await app.inject({ method: 'GET', url: '/bo/product/valueHelp/uom' })
+    const enNames = (enRes.json().items as { slug: string; name: string }[])
+      .reduce<Record<string, string>>((acc, r) => { acc[r.slug] = r.name; return acc }, {})
+    expect(enNames).toEqual({ kg: 'Kilogram', m: 'Meter' })
+
+    await app.close()
+    await db.close()
+  })
+
+  it('falls back to fallbackLocale when no sessionParams are configured (legacy path)', async () => {
+    const db = createDatabase({ connectionString: testDb.connectionString })
+    expect(db.hasSessionParams).toBe(false)
+
+    const app = Fastify()
+    registerProjection(app, db, {
+      projection: productProjection,
+      view: productView,
+      extractContext: () => ({ app, db, locale: 'de' }),
+    })
+
+    // No sessionParams → current_setting('app.locale', true) is NULL → t_req join misses → fallback wins
+    const res = await app.inject({ method: 'GET', url: '/bo/product/valueHelp/uom' })
+    const names = (res.json().items as { slug: string; name: string }[])
+      .reduce<Record<string, string>>((acc, r) => { acc[r.slug] = r.name; return acc }, {})
+    expect(names).toEqual({ kg: 'Kilogram', m: 'Meter' })
+
+    await app.close()
+    await db.close()
+  })
+})

--- a/packages/pgbo/src/bo/enrich-associations.ts
+++ b/packages/pgbo/src/bo/enrich-associations.ts
@@ -6,10 +6,15 @@
 // composition gives you the caller-locale name lifted onto the parent.
 
 import type { Database } from '../query/client.js'
+import type { TransactionClient } from '../query/transaction.js'
 import type { AssociationDef, AssociationTargetBO, ViewDef } from '../schema/definitions.js'
 import type { BusinessObjectDef, ActionContext } from './types.js'
 import type { WhereConditions } from '../query/where.js'
 import { enrichCompositions } from './enrich.js'
+
+/** Database or a request-scoped TransactionClient — used so association reads
+ * see session params when callers wrap routes in `db.withContext` (issue #42). */
+type DbOrTx = Database | TransactionClient
 
 function isBusinessObjectTarget(target: unknown): target is AssociationTargetBO {
   return typeof target === 'object' && target !== null
@@ -42,7 +47,7 @@ export interface EnrichAssociationsOptions {
  * Returns new objects; does not mutate input.
  */
 export async function enrichAssociations<T extends Record<string, unknown>>(
-  db: Database,
+  db: DbOrTx,
   bo: BusinessObjectDef,
   items: readonly T[],
   opts: EnrichAssociationsOptions = {},

--- a/packages/pgbo/src/bo/enrich.ts
+++ b/packages/pgbo/src/bo/enrich.ts
@@ -2,11 +2,17 @@
 // (issue #018 base + #019 nested children + #13 cardinality/where/merge + #25 link-table M2M)
 
 import type { Database } from '../query/client.js'
+import type { TransactionClient } from '../query/transaction.js'
 import type { TableDef, ViewDef } from '../schema/definitions.js'
 import type { BusinessObjectDef, CompositionDef, AnyCompositionDef, LinkCompositionDef, BoTarget, ActionContext } from './types.js'
 import { isLinkComposition } from './types.js'
 import { toCamelCase } from '../query/select.js'
 import type { WhereConditions } from '../query/where.js'
+
+/** Either the top-level Database or a request-scoped TransactionClient — used so
+ * read paths see `current_setting()` when callers wrap the route in `db.withContext`
+ * (issue #42). Both expose the same `from` / `_table` / `query` surface this file uses. */
+type DbOrTx = Database | TransactionClient
 
 function resolveTable(compDef: CompositionDef): TableDef | undefined {
   return compDef.table ?? compDef.view?.source
@@ -87,7 +93,7 @@ type LevelResult = Map<string, { def: AnyCompositionDef; grouped: Map<unknown, R
  * Returns a Map<parentValue, targetRow[]> with columns already narrowed per `columns`.
  */
 async function loadLinkComposition(
-  db: Database,
+  db: DbOrTx,
   def: LinkCompositionDef,
   parentIds: unknown[],
   opts: EnrichOptions,
@@ -175,7 +181,7 @@ async function loadLinkComposition(
 }
 
 async function loadCompositionLevel(
-  db: Database,
+  db: DbOrTx,
   compositions: readonly (readonly [string, AnyCompositionDef])[],
   parentKeyField: string,
   items: readonly Record<string, unknown>[],
@@ -254,7 +260,7 @@ function shapeChildren(def: AnyCompositionDef, children: Record<string, unknown>
  * attach them to parent rows. Returns new objects — does not mutate input.
  */
 export async function enrichCompositions<T extends Record<string, unknown>>(
-  db: Database,
+  db: DbOrTx,
   bo: BusinessObjectDef,
   items: readonly T[],
   opts: EnrichOptions = {},

--- a/packages/pgbo/src/query/client.ts
+++ b/packages/pgbo/src/query/client.ts
@@ -121,6 +121,14 @@ export interface Database extends Queryable {
   /** Optional cache provider registered via DatabaseConfig. undefined when no cache was configured. */
   readonly cache?: CacheProvider
 
+  /**
+   * True when `DatabaseConfig.sessionParams` was set with at least one resolver.
+   * `@pgbo/fastify` reads this to decide whether to wrap request handlers in
+   * `db.withContext` — skipping the wrap entirely when no params are configured
+   * so that apps without session params don't pay an extra transaction per request.
+   */
+  readonly hasSessionParams: boolean
+
   /** Close the connection pool */
   close(): Promise<void>
 
@@ -185,9 +193,13 @@ export function createDatabase(config: DatabaseConfig): Database {
     return builder
   }
 
+  const hasSessionParams = config.sessionParams !== undefined
+    && Object.keys(config.sessionParams).length > 0
+
   const db: Database = {
     pool,
     cache,
+    hasSessionParams,
 
     query: queryFn,
 


### PR DESCRIPTION
## Summary

Views with \`.translatedJoin()\` rely on \`current_setting('app.locale', true)\` to filter by the request locale. Until now, hitting one through \`registerProjection\` always returned the fallback locale because the route never called \`db.withContext\` to emit the per-request \`SET LOCAL\`.

Now every read handler is wrapped automatically when \`sessionParams\` is configured.

## Scope of the wrap

- \`GET {prefix}\` (list), \`GET {prefix}/:param\` (detail) — wrapped
- \`GET /bo/{name}/valueHelp/{vh}\` — wrapped
- \`PUT\` / \`DELETE\` projection-visibility pre-fetch — wrapped (the actual \`bo.update\` / \`bo.delete\` runs unwrapped because writes don't depend on \`current_setting\`)
- \`POST\` / custom actions — unwrapped (locale-aware custom actions call \`db.withContext\` explicitly inside the handler)
- \`registerViewRoute\` reads — wrapped

When \`sessionParams\` is empty (\`db.hasSessionParams === false\`), the wrap is a no-op — apps without session params don't pay an extra transaction round-trip per request.

## New API

- **\`Database.hasSessionParams: boolean\`** — true when \`DatabaseConfig\` set at least one \`sessionParams\` resolver. The Fastify adapter reads this to decide whether to wrap.

## Internal type widening (compatible)

- \`paginateView\`, \`enrichCompositions\`, \`enrichAssociations\` now accept \`Database | TransactionClient\` (exported as \`DbOrTx\` from \`@pgbo/fastify\`). Existing callers passing \`Database\` still work; the Fastify routes pass the scoped tx inside \`db.withContext\` so reads observe \`SET LOCAL\`.

## Test plan

- [x] New \`auto-withcontext.test.ts\`: end-to-end with a real translated_join view, two locales (\`de\`, \`en\`), confirms different locales return different translations through the value-help route. Plus a control test verifying the legacy fallback path still works when no sessionParams are configured.
- [x] All 479 tests pass (399 core + 80 fastify), lint + typecheck clean

## Workaround removed

Apps that hand-wrapped each query in \`db.withContext\` to work around the missing wiring can drop those calls — \`registerProjection\` does it for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)