### PR TITLE
feat!: lock URL conventions in @pgbo/fastify (closes #44)

### DIFF
--- a/.changeset/lock-url-conventions.md
+++ b/.changeset/lock-url-conventions.md
@@ -1,0 +1,53 @@
+---
+"@pgbo/core": major
+"@pgbo/fastify": major
+---
+
+Lock URL conventions in `@pgbo/fastify` — no manual route prefix overrides (closes #44). **Breaking change.**
+
+Every projection's HTTP surface now lives at exactly one URL pattern derived from the projection name, with no per-BO or per-route knob to override it:
+
+```
+GET    /bo/{projection}                     list
+GET    /bo/{projection}/{paramValue}        detail
+POST   /bo/{projection}                     create
+PUT    /bo/{projection}/{paramValue}        update
+DELETE /bo/{projection}/{paramValue}        delete
+GET    /meta/{projection}                   metadata
+GET    /bo/{projection}/valueHelp/{vh}      value help
+POST   /bo/{projection}/{action}            custom action
+GET    /view/{view}                         view route
+GET    /view/{view}/meta                    view metadata
+```
+
+### Removed
+
+- `BOConfig.routePrefix` and `BusinessObjectDef.routePrefix`
+- `ProjectionRouteConfig.prefix`
+- `ViewRouteConfig.prefix`
+- `BOMeta.routePrefix`
+
+### Why
+
+- **Frontend simplicity** — with only the projection name in hand the UI can build any URL. No catalog lookup needed for the URL part.
+- **Refactor safety** — renaming a projection rewrites every URL automatically; the frontend can't lag behind.
+- **Multi-tenant routing stays in middleware** — API versioning, tenant prefixes, etc. belong in Fastify's encapsulation layer (`app.register(routes, { prefix: '/v1' })`), not on each BO.
+
+### Migration
+
+Replace per-BO / per-projection prefix configs with the canonical layout. URLs the frontend used to call:
+
+```
+/api/warehouses           → /bo/warehouse
+/api/admin/areas          → /bo/areaAdmin   (rename projection 'area' → 'areaAdmin')
+/api/public/areas         → /bo/areaPublic
+```
+
+Two projections over the same BO that previously shared a prefix must now pick distinct projection names. For tenant or version prefixes, wrap `registerProjection` calls in a Fastify plugin and use Fastify's `prefix` at registration time:
+
+```ts
+app.register(async (api) => {
+  registerProjection(api, db, { projection: warehouseProjection, ... })
+}, { prefix: '/v1' })
+// → /v1/bo/warehouse, /v1/meta/warehouse, etc.
+```

--- a/docs/bo.md
+++ b/docs/bo.md
@@ -47,12 +47,11 @@ const bo = defineBO(stockJournalTable, {
 
 ## List & Route Metadata
 
-BOs carry route-level metadata so consuming apps don't need per-BO config duplication:
+BOs carry list-level metadata so consuming apps don't need per-BO config duplication:
 
 ```typescript
 const areaBO = defineBO(areaTable, {
   paramField: 'id',
-  routePrefix: '/api/areas',
   orderBy: 'sortOrder',
   orderDir: 'asc',
   cacheTags: ['area', 'navigation'],
@@ -66,7 +65,6 @@ const areaBO = defineBO(areaTable, {
 })
 ```
 
-- `routePrefix` — default route path for the consuming framework
 - `orderBy` / `orderDir` — default sort for list queries
 - `cacheTags` — cache invalidation tags
 - `virtualFields` — fields populated by `transformItems`, merged into `boMeta()` output
@@ -502,20 +500,19 @@ const activeCustomer = defineProjection(customerBO, {
 import { registerProjection } from '@pgbo/fastify'
 
 registerProjection(app, db, {
-  projection: areaPublic,
+  projection: areaPublic,           // → routes under /bo/areaPublic
   view: areaView,
   extractContext: req => ({ app, db, locale: 'en' }),
 })
 
 registerProjection(app, db, {
-  projection: areaAdmin,
+  projection: areaAdmin,            // → routes under /bo/areaAdmin
   view: areaView,
-  prefix: '/api/admin/areas',
   extractContext: /* ... */,
 })
 ```
 
-Multiple projections over the same BO coexist — you can surface a read-only public API, a CRUD admin API, and a reporting projection side-by-side without duplicating the BO.
+URL layout is locked to `/bo/{projection.name}` (issue #44) — no per-projection prefix knob. Multiple projections over the same BO coexist by picking different `name`s. For API versioning or tenant prefixes, use Fastify's encapsulation: `app.register(routes, { prefix: '/v1' })`.
 
 ### Validation
 

--- a/docs/fastify.md
+++ b/docs/fastify.md
@@ -68,7 +68,7 @@ registerProjection(app, db, {
 await app.listen({ port: 3000 })
 ```
 
-This produces, under `/bo/warehouse` (the default prefix):
+This produces, under the canonical `/bo/{projection.name}` layout:
 
 | Method | Path | Purpose |
 |---|---|---|
@@ -79,7 +79,7 @@ This produces, under `/bo/warehouse` (the default prefix):
 | `DELETE` | `/bo/warehouse/:slug`         | Delete |
 | `GET`    | `/meta/warehouse`             | Frontend-consumable field metadata |
 
-The `:param` segment is driven by `bo.paramField`, not hardcoded to `id`.
+The `:param` segment is driven by `bo.paramField`, not hardcoded to `id`. The URL prefix is locked to `/bo/{projection.name}` (issue #44) — no per-BO or per-route override. For API versioning or tenant prefixes use Fastify's encapsulation: `app.register(routes, { prefix: '/v1' })`.
 
 ## `registerProjection`
 
@@ -91,8 +91,6 @@ interface ProjectionRouteConfig {
   readonly projection: ProjectionDef
   /** The view to query. Defaults to projection.bo.root if it's a ViewDef. */
   readonly view?: ViewDef
-  /** Route prefix override. Defaults to projection.bo.routePrefix or `/bo/${projection.name}`. */
-  readonly prefix?: string
   /** Include global (tenant-less) rows alongside tenant-scoped rows. */
   readonly includeGlobal?: boolean
   /** Tenant column name. Default: 'tenantId'. */

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -57,7 +57,6 @@ interface PublicBoMeta {
   associations: AssociationMeta[]               // foreign-key navigations
   compositions: CompositionMeta[]               // nested children
   valueHelps: ValueHelpMeta[]                   // dropdown sources
-  routePrefix?: string
   orderBy?: string
   orderDir?: 'asc' | 'desc'
   cacheTags?: string[]
@@ -294,7 +293,7 @@ const meta = boMeta(warehouseBO, {
   translations: { table: warehouseTranslationTable, parentKey: 'warehouseId', fields: ['name'] },
 })
 // Extends viewMeta with:
-//   paramField, readOnly, compositions, valueHelps, routePrefix, orderBy, orderDir, cacheTags
+//   paramField, readOnly, compositions, valueHelps, orderBy, orderDir, cacheTags
 //   + injected translation fields (kind: 'translation', searchable: true, filterable: { type: 'text' })
 //   + injected virtual fields (from bo.virtualFields)
 ```

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -141,7 +141,10 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
   const bo = projection.bo
   const boMethods = bo as unknown as TypedBoMethods
   const viewDef = resolveView(config)
-  const prefix = config.prefix ?? bo.routePrefix ?? `/bo/${projection.name}`
+  // URL layout is locked to `/bo/{projection.name}` (issue #44). Versioning,
+  // tenant prefixes, etc. belong in Fastify's encapsulation layer
+  // (`app.register(routes, { prefix: '/v1' })`), not on each BO.
+  const prefix = `/bo/${projection.name}`
   const paramField = bo.paramField
   const tenantCol = config.tenantColumn ?? 'tenantId'
   const includeGlobal = config.includeGlobal ?? false
@@ -407,7 +410,8 @@ export function registerProjection(app: FastifyInstance, db: Database, config: P
  */
 export function registerViewRoute(app: FastifyInstance, db: Database, config: ViewRouteConfig): void {
   const viewDef = config.view
-  const prefix = config.prefix ?? `/view/${viewDef.name}`
+  // URL layout is locked to `/view/{view.name}` (issue #44).
+  const prefix = `/view/${viewDef.name}`
 
   // OpenAPI schema (issue #38)
   const swagger: SwaggerConfig = config.swagger ?? {}

--- a/packages/pgbo-fastify/src/types.ts
+++ b/packages/pgbo-fastify/src/types.ts
@@ -18,8 +18,6 @@ export interface ProjectionRouteConfig {
   readonly projection: ProjectionDef
   /** The view to query (defaults to projection.bo.root if it's a ViewDef) */
   readonly view?: ViewDef
-  /** Route prefix override (defaults to projection.bo.routePrefix or `/bo/${projection.name}`) */
-  readonly prefix?: string
   /** Include global (tenant-less) rows alongside tenant-scoped rows */
   readonly includeGlobal?: boolean
   /** Tenant column name (default: 'tenantId') */
@@ -73,8 +71,6 @@ export interface FileResponse {
 export interface ViewRouteConfig {
   /** The view to expose */
   readonly view: ViewDef
-  /** Route prefix override (defaults to `/view/${view.name}`) */
-  readonly prefix?: string
   /** Extract context from request */
   readonly extractContext: (req: FastifyRequest) => RouteContext | Promise<RouteContext>
   /** OpenAPI / Swagger schema generation (issue #38). */

--- a/packages/pgbo-fastify/tests/association-enrichment.test.ts
+++ b/packages/pgbo-fastify/tests/association-enrichment.test.ts
@@ -57,7 +57,7 @@ describe('Association enrichment through HTTP (issue #23)', () => {
 
   const pageBO = defineBO(pageTable, {
     paramField: 'id',
-    routePrefix: '/api/pages',
+    
     actions: { create: {} },
     associations: {
       area: {
@@ -103,7 +103,7 @@ describe('Association enrichment through HTTP (issue #23)', () => {
 
   it('GET list merges target.name as areaName at $locale', async () => {
     const app = mkApp('en')
-    const res = await app.inject({ method: 'GET', url: '/api/pages' })
+    const res = await app.inject({ method: 'GET', url: '/bo/page' })
     expect(res.statusCode).toBe(200)
     const body = res.json()
     expect(body.items).toHaveLength(3)
@@ -114,7 +114,7 @@ describe('Association enrichment through HTTP (issue #23)', () => {
 
   it('GET list resolves different locale through target compositions', async () => {
     const app = mkApp('de')
-    const res = await app.inject({ method: 'GET', url: '/api/pages' })
+    const res = await app.inject({ method: 'GET', url: '/bo/page' })
     const names = res.json().items.map((i: { areaName: string }) => i.areaName)
     expect(names).toEqual(['Navigation DE', 'Navigation DE', 'Verwaltung'])
     await app.close()
@@ -122,7 +122,7 @@ describe('Association enrichment through HTTP (issue #23)', () => {
 
   it('GET detail enriches a single row too', async () => {
     const app = mkApp('en')
-    const res = await app.inject({ method: 'GET', url: '/api/pages/1' })
+    const res = await app.inject({ method: 'GET', url: '/bo/page/1' })
     expect(res.statusCode).toBe(200)
     expect(res.json()).toMatchObject({ id: 1, slug: 'home', areaName: 'Navigation' })
     await app.close()

--- a/packages/pgbo-fastify/tests/custom-actions.test.ts
+++ b/packages/pgbo-fastify/tests/custom-actions.test.ts
@@ -22,7 +22,7 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
 
   const roleBO = defineBO(roleTable, {
     paramField: 'id',
-    routePrefix: '/api/roles',
+    
     actions: {
       // Standard
       create: {},
@@ -148,7 +148,7 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
   it('defaults Content-Disposition to attachment when inline is false', async () => {
     const testBO = defineBO(roleTable, {
       paramField: 'id',
-      routePrefix: '/api/downloads',
+      
       actions: {
         download: {
           handler: () => ({
@@ -182,7 +182,7 @@ describe('Custom BO actions exposed as HTTP routes (issues #5 + #7)', () => {
   it('returns a 500 when the action throws', async () => {
     const throwingBO = defineBO(roleTable, {
       paramField: 'id',
-      routePrefix: '/api/broken',
+      
       actions: {
         broken: {
           handler: () => { throw new Error('boom') },

--- a/packages/pgbo-fastify/tests/features.test.ts
+++ b/packages/pgbo-fastify/tests/features.test.ts
@@ -31,7 +31,7 @@ const warehouseVH = view('warehouse_vh').from(warehouseTable)
 const warehouseBO = defineBO(warehouseTable, {
   paramField: 'slug',
   actions: { create: {}, update: {}, delete: {} },
-  routePrefix: '/api/warehouses',
+  
   valueHelps: { warehouse: warehouseVH },
 })
 
@@ -72,7 +72,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses?search=Main' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse?search=Main' })
       const body = res.json()
       expect(body.items).toHaveLength(1)
       expect(body.items[0].slug).toBe('main')
@@ -87,7 +87,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses?search=return' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse?search=return' })
       const body = res.json()
       expect(body.items).toHaveLength(1)
       expect(body.items[0].slug).toBe('returns')
@@ -144,14 +144,14 @@ describe('pgbo-fastify — issue 026 features', () => {
       })
 
       await app.inject({
-        method: 'POST', url: '/api/warehouses',
+        method: 'POST', url: '/bo/warehouse',
         payload: { id: 99, slug: 'temp', name: 'Temp' },
       })
       await app.inject({
-        method: 'PUT', url: '/api/warehouses/temp',
+        method: 'PUT', url: '/bo/warehouse/temp',
         payload: { name: 'Temp Renamed' },
       })
-      await app.inject({ method: 'DELETE', url: '/api/warehouses/temp' })
+      await app.inject({ method: 'DELETE', url: '/bo/warehouse/temp' })
 
       expect(calls.map(c => c.action)).toEqual(['create', 'update', 'delete'])
       await app.close()
@@ -168,7 +168,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse' })
       const body = res.json()
       const global = body.items.find((i: any) => i.slug === 'global-wh')
       const main = body.items.find((i: any) => i.slug === 'main')
@@ -185,7 +185,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse' })
       const body = res.json()
       expect(body.items[0].global).toBeUndefined()
       await app.close()
@@ -201,7 +201,7 @@ describe('pgbo-fastify — issue 026 features', () => {
       })
 
       const res = await app.inject({
-        method: 'PUT', url: '/api/warehouses/global-wh',
+        method: 'PUT', url: '/bo/warehouse/global-wh',
         payload: { name: 'Hijacked' },
       })
       expect(res.statusCode).toBe(403)
@@ -217,7 +217,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'DELETE', url: '/api/warehouses/global-wh' })
+      const res = await app.inject({ method: 'DELETE', url: '/bo/warehouse/global-wh' })
       expect(res.statusCode).toBe(403)
       await app.close()
     })
@@ -233,7 +233,7 @@ describe('pgbo-fastify — issue 026 features', () => {
         extractContext: () => ({ app, db: testDb.db, tenantId: 't1', locale: 'en' }),
       })
 
-      const delRes = await app.inject({ method: 'DELETE', url: '/api/warehouses/temp-tenant' })
+      const delRes = await app.inject({ method: 'DELETE', url: '/bo/warehouse/temp-tenant' })
       expect(delRes.statusCode).toBe(200)
       await app.close()
     })

--- a/packages/pgbo-fastify/tests/projection-enrich-ctx.test.ts
+++ b/packages/pgbo-fastify/tests/projection-enrich-ctx.test.ts
@@ -76,7 +76,7 @@ describe('issue #20 — registerProjection forwards ctx to enrichCompositions', 
     registerProjection(app, testDb.db, {
       projection: areaProjection,
       view: areaView,
-      prefix: '/api/areas',
+      
       extractContext: () => ({ app, db: testDb.db, locale }),
     })
     return app
@@ -84,7 +84,7 @@ describe('issue #20 — registerProjection forwards ctx to enrichCompositions', 
 
   it('GET list resolves $locale from ctx — no 500', async () => {
     const app = mkApp('en')
-    const res = await app.inject({ method: 'GET', url: '/api/areas' })
+    const res = await app.inject({ method: 'GET', url: '/bo/area' })
     expect(res.statusCode).toBe(200)
     const body = res.json()
     // merge: ['name'] lifts translation.name onto parent
@@ -95,7 +95,7 @@ describe('issue #20 — registerProjection forwards ctx to enrichCompositions', 
 
   it('different locale → different merged name', async () => {
     const app = mkApp('de')
-    const res = await app.inject({ method: 'GET', url: '/api/areas' })
+    const res = await app.inject({ method: 'GET', url: '/bo/area' })
     expect(res.statusCode).toBe(200)
     const byId = Object.fromEntries(res.json().items.map((i: { id: number; name: string }) => [i.id, i.name]))
     expect(byId).toEqual({ 1: 'Navigation DE', 2: 'Verwaltung' })
@@ -104,7 +104,7 @@ describe('issue #20 — registerProjection forwards ctx to enrichCompositions', 
 
   it('GET detail resolves $locale from ctx', async () => {
     const app = mkApp('de')
-    const res = await app.inject({ method: 'GET', url: '/api/areas/1' })
+    const res = await app.inject({ method: 'GET', url: '/bo/area/1' })
     expect(res.statusCode).toBe(200)
     expect(res.json().name).toBe('Navigation DE')
     await app.close()

--- a/packages/pgbo-fastify/tests/projections.test.ts
+++ b/packages/pgbo-fastify/tests/projections.test.ts
@@ -61,7 +61,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
       registerProjection(app, testDb.db, {
         projection: areaPublic,
         view: areaView,
-        prefix: '/api/public/areas',
+        
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
       return app
@@ -69,7 +69,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('read-only projection exposes GET list', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/api/public/areas' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaPublic' })
       expect(res.statusCode).toBe(200)
       expect(res.json().items).toHaveLength(3)
       await app.close()
@@ -77,7 +77,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('read-only projection exposes GET detail', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/api/public/areas/1' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaPublic/1' })
       expect(res.statusCode).toBe(200)
       expect(res.json().slug).toBe('nav')
       await app.close()
@@ -94,7 +94,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
     it('read-only projection does NOT expose POST create', async () => {
       const app = mkApp()
       const res = await app.inject({
-        method: 'POST', url: '/api/public/areas',
+        method: 'POST', url: '/bo/areaPublic',
         payload: { id: 99, slug: 'x', name: 'X' },
       })
       expect(res.statusCode).toBe(404)
@@ -104,7 +104,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
     it('read-only projection does NOT expose PUT update', async () => {
       const app = mkApp()
       const res = await app.inject({
-        method: 'PUT', url: '/api/public/areas/1', payload: { name: 'Hijacked' },
+        method: 'PUT', url: '/bo/areaPublic/1', payload: { name: 'Hijacked' },
       })
       expect(res.statusCode).toBe(404)
       await app.close()
@@ -112,7 +112,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('read-only projection does NOT expose DELETE', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'DELETE', url: '/api/public/areas/1' })
+      const res = await app.inject({ method: 'DELETE', url: '/bo/areaPublic/1' })
       expect(res.statusCode).toBe(404)
       await app.close()
     })
@@ -139,7 +139,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
       registerProjection(app, testDb.db, {
         projection: areaAdmin,
         view: areaView,
-        prefix: '/api/admin/areas',
+        
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
       return app
@@ -163,12 +163,12 @@ describe('Projections as HTTP surface (issue #15)', () => {
     it('standard CRUD is exposed when whitelisted', async () => {
       const app = mkApp()
       const post = await app.inject({
-        method: 'POST', url: '/api/admin/areas',
+        method: 'POST', url: '/bo/areaAdmin',
         payload: { id: 100, slug: 'new', name: 'New' },
       })
       expect(post.statusCode).toBe(201)
 
-      const del = await app.inject({ method: 'DELETE', url: '/api/admin/areas/100' })
+      const del = await app.inject({ method: 'DELETE', url: '/bo/areaAdmin/100' })
       expect(del.statusCode).toBe(200)
       await app.close()
     })
@@ -186,7 +186,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
       registerProjection(app, testDb.db, {
         projection: areaMobile,
         view: areaView,
-        prefix: '/api/mobile/areas',
+        
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
       return app
@@ -194,7 +194,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('list response omits non-projected columns', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/api/mobile/areas' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaMobile' })
       const body = res.json()
       expect(body.items[0]).toEqual({ id: 1, slug: 'nav', name: 'Navigation' })
       expect(body.items[0].internalNote).toBeUndefined()
@@ -203,7 +203,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('detail response omits non-projected columns', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/api/mobile/areas/1' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaMobile/1' })
       const body = res.json()
       expect(body).toEqual({ id: 1, slug: 'nav', name: 'Navigation' })
       expect(body.internalNote).toBeUndefined()
@@ -232,7 +232,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
       registerProjection(app, testDb.db, {
         projection: publishedOnly,
         view: areaView,
-        prefix: '/api/pub/areas',
+        
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
       return app
@@ -240,7 +240,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('list filters by root WHERE', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/api/pub/areas' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaPublished' })
       const slugs = res.json().items.map((i: { slug: string }) => i.slug).sort()
       expect(slugs).toEqual(['admin', 'nav'])  // 'draft' filtered out
       await app.close()
@@ -249,14 +249,14 @@ describe('Projections as HTTP surface (issue #15)', () => {
     it('detail 404s for out-of-scope rows', async () => {
       const app = mkApp()
       // draft (id 3) exists but is invisible through this projection
-      const res = await app.inject({ method: 'GET', url: '/api/pub/areas/3' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaPublished/3' })
       expect(res.statusCode).toBe(404)
       await app.close()
     })
 
     it('detail succeeds for in-scope rows', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'GET', url: '/api/pub/areas/1' })
+      const res = await app.inject({ method: 'GET', url: '/bo/areaPublished/1' })
       expect(res.statusCode).toBe(200)
       await app.close()
     })
@@ -264,7 +264,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
     it('update on out-of-scope row 404s', async () => {
       const app = mkApp()
       const res = await app.inject({
-        method: 'PUT', url: '/api/pub/areas/3', payload: { name: 'Hijacked' },
+        method: 'PUT', url: '/bo/areaPublished/3', payload: { name: 'Hijacked' },
       })
       expect(res.statusCode).toBe(404)
       await app.close()
@@ -272,7 +272,7 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
     it('delete on out-of-scope row 404s', async () => {
       const app = mkApp()
-      const res = await app.inject({ method: 'DELETE', url: '/api/pub/areas/3' })
+      const res = await app.inject({ method: 'DELETE', url: '/bo/areaPublished/3' })
       expect(res.statusCode).toBe(404)
       await app.close()
     })
@@ -289,20 +289,20 @@ describe('Projections as HTTP surface (issue #15)', () => {
 
       const app = Fastify()
       registerProjection(app, testDb.db, {
-        projection: areaRead, view: areaView, prefix: '/public/areas',
+        projection: areaRead, view: areaView, 
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
       registerProjection(app, testDb.db, {
-        projection: areaFull, view: areaView, prefix: '/admin/areas',
+        projection: areaFull, view: areaView, 
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
       // Read available on both
-      expect((await app.inject({ method: 'GET', url: '/public/areas' })).statusCode).toBe(200)
-      expect((await app.inject({ method: 'GET', url: '/admin/areas' })).statusCode).toBe(200)
+      expect((await app.inject({ method: 'GET', url: '/bo/areaRead' })).statusCode).toBe(200)
+      expect((await app.inject({ method: 'GET', url: '/bo/areaFull' })).statusCode).toBe(200)
 
       // Delete only on admin
-      expect((await app.inject({ method: 'DELETE', url: '/public/areas/1' })).statusCode).toBe(404)
+      expect((await app.inject({ method: 'DELETE', url: '/bo/areaRead/1' })).statusCode).toBe(404)
       // rebuildCache only on admin
       expect((await app.inject({ method: 'POST', url: '/bo/areaRead/rebuildCache' })).statusCode).toBe(404)
       expect((await app.inject({ method: 'POST', url: '/bo/areaFull/rebuildCache' })).statusCode).toBe(200)

--- a/packages/pgbo-fastify/tests/route-prefix-collision.test.ts
+++ b/packages/pgbo-fastify/tests/route-prefix-collision.test.ts
@@ -1,6 +1,7 @@
 // Regression test for issue #24:
-// When a BO/projection has no explicit routePrefix, registerProjection must not
-// crash Fastify at boot with "Method 'GET' already declared for route '/bo/X'".
+// `/meta/{name}` lives in its own namespace (not `/bo/{name}/meta`) so it can't
+// collide with the canonical `/bo/{projection.name}` list route under any name
+// (issue #24 + #44 — URL layout is now locked to that pattern, no overrides).
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import Fastify from 'fastify'
@@ -22,10 +23,9 @@ const thingTable = table('thing', {
 
 const thingView = view('thing_view').from(thingTable)
 
-describe('issue #24 — default routePrefix does not collide with metadata route', () => {
+describe('issue #24 — canonical /bo/{name} does not collide with /meta/{name}', () => {
   let testDb: TestDatabase
 
-  // A BO WITHOUT routePrefix — the default fallback triggered the bug
   const thingBO = defineBO(thingTable, {
     paramField: 'id',
     actions: { create: {}, update: {}, delete: {} },

--- a/packages/pgbo-fastify/tests/routes.test.ts
+++ b/packages/pgbo-fastify/tests/routes.test.ts
@@ -22,7 +22,7 @@ const warehouseView = view('warehouse_view').from(warehouseTable)
 const warehouseBO = defineBO(warehouseTable, {
   paramField: 'slug',
   actions: { create: {}, update: {}, delete: {} },
-  routePrefix: '/api/warehouses',
+  
   orderBy: 'name',
 })
 
@@ -60,7 +60,7 @@ describe('pgbo-fastify route factory', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse' })
       const body = res.json()
       expect(res.statusCode).toBe(200)
       expect(body.items).toHaveLength(3)
@@ -78,7 +78,7 @@ describe('pgbo-fastify route factory', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses?limit=1&page=2' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse?limit=1&page=2' })
       const body = res.json()
       expect(body.items).toHaveLength(1)
       expect(body.page).toBe(2)
@@ -94,7 +94,7 @@ describe('pgbo-fastify route factory', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses/main' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse/main' })
       const body = res.json()
       expect(res.statusCode).toBe(200)
       expect(body.slug).toBe('main')
@@ -110,7 +110,7 @@ describe('pgbo-fastify route factory', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'GET', url: '/api/warehouses/nonexistent' })
+      const res = await app.inject({ method: 'GET', url: '/bo/warehouse/nonexistent' })
       expect(res.statusCode).toBe(404)
       await app.close()
     })
@@ -140,7 +140,7 @@ describe('pgbo-fastify route factory', () => {
       })
 
       const res = await app.inject({
-        method: 'POST', url: '/api/warehouses',
+        method: 'POST', url: '/bo/warehouse',
         payload: { id: 10, slug: 'new-wh', name: 'New WH' },
       })
       expect(res.statusCode).toBe(201)
@@ -160,7 +160,7 @@ describe('pgbo-fastify route factory', () => {
         extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
       })
 
-      const res = await app.inject({ method: 'DELETE', url: '/api/warehouses/temp' })
+      const res = await app.inject({ method: 'DELETE', url: '/bo/warehouse/temp' })
       expect(res.statusCode).toBe(200)
 
       const check = await testDb.raw("SELECT * FROM warehouse WHERE slug = 'temp'")

--- a/packages/pgbo/src/bo/index.ts
+++ b/packages/pgbo/src/bo/index.ts
@@ -93,7 +93,6 @@ export function defineBO<
     associations,
     valueHelps,
     isReadOnly: !config.actions || Object.keys(config.actions).length === 0,
-    routePrefix: config.routePrefix,
     orderBy: config.orderBy,
     orderDir: config.orderDir,
     cacheTags: config.cacheTags,

--- a/packages/pgbo/src/bo/types.ts
+++ b/packages/pgbo/src/bo/types.ts
@@ -122,7 +122,6 @@ export interface BusinessObjectDef {
   readonly associations: Readonly<Record<string, AssociationDef>>
   readonly valueHelps: Readonly<Record<string, ViewDef>>
   readonly isReadOnly: boolean
-  readonly routePrefix?: string
   readonly orderBy?: string
   readonly orderDir?: 'asc' | 'desc'
   readonly cacheTags?: readonly string[]
@@ -163,7 +162,6 @@ export interface BOConfig<C extends Record<string, AnyColumnBuilder> = Record<st
   compositions?: Record<string, AnyCompositionDef | ViewDef | TableDef>
   associations?: Record<string, AssociationDef>
   valueHelps?: Record<string, ViewDef>
-  routePrefix?: string
   orderBy?: string
   orderDir?: 'asc' | 'desc'
   cacheTags?: string[]

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -288,7 +288,6 @@ export function boMeta(
     readOnly: bo.isReadOnly,
     compositions,
     valueHelps,
-    routePrefix: bo.routePrefix,
     orderBy: bo.orderBy,
     orderDir: bo.orderDir,
     cacheTags: bo.cacheTags,

--- a/packages/pgbo/src/metadata/types.ts
+++ b/packages/pgbo/src/metadata/types.ts
@@ -76,7 +76,6 @@ export interface BOMeta extends ViewMeta {
   readonly readOnly: boolean
   readonly compositions: readonly CompositionMeta[]
   readonly valueHelps: readonly ValueHelpMeta[]
-  readonly routePrefix?: string
   readonly orderBy?: string
   readonly orderDir?: 'asc' | 'desc'
   readonly cacheTags?: readonly string[]

--- a/packages/pgbo/tests/bo/config-metadata.test.ts
+++ b/packages/pgbo/tests/bo/config-metadata.test.ts
@@ -14,32 +14,28 @@ const areaTable = table('area', {
 })
 
 describe('BOConfig list/search/filter metadata (issue 021)', () => {
-  it('carries routePrefix, orderBy, orderDir, cacheTags', () => {
+  it('carries orderBy, orderDir, cacheTags', () => {
     const bo = defineBO(areaTable, {
       paramField: 'id',
-      routePrefix: '/api/areas',
       orderBy: 'sortOrder',
       orderDir: 'asc',
       cacheTags: ['area', 'navigation'],
     })
 
-    expect(bo.routePrefix).toBe('/api/areas')
     expect(bo.orderBy).toBe('sortOrder')
     expect(bo.orderDir).toBe('asc')
     expect(bo.cacheTags).toEqual(['area', 'navigation'])
   })
 
-  it('boMeta() includes route metadata', () => {
+  it('boMeta() includes orderBy/orderDir/cacheTags (URL prefix is locked, issue #44)', () => {
     const bo = defineBO(areaTable, {
       paramField: 'id',
-      routePrefix: '/api/areas',
       orderBy: 'sortOrder',
       orderDir: 'desc',
       cacheTags: ['area'],
     })
 
     const meta = boMeta(bo)
-    expect(meta.routePrefix).toBe('/api/areas')
     expect(meta.orderBy).toBe('sortOrder')
     expect(meta.orderDir).toBe('desc')
     expect(meta.cacheTags).toEqual(['area'])
@@ -91,7 +87,6 @@ describe('BOConfig list/search/filter metadata (issue 021)', () => {
 
   it('optional fields default to undefined', () => {
     const bo = defineBO(areaTable, { paramField: 'id' })
-    expect(bo.routePrefix).toBeUndefined()
     expect(bo.orderBy).toBeUndefined()
     expect(bo.cacheTags).toBeUndefined()
     expect(bo.virtualFields).toBeUndefined()


### PR DESCRIPTION
## Summary

Every projection's HTTP surface now lives at exactly one URL pattern derived from the projection name. URLs are an implementation detail of \`@pgbo/fastify\`, not a per-BO knob.

\`\`\`
GET    /bo/{projection}                     list
GET    /bo/{projection}/{paramValue}        detail
POST   /bo/{projection}                     create
PUT    /bo/{projection}/{paramValue}        update
DELETE /bo/{projection}/{paramValue}        delete
GET    /meta/{projection}                   metadata
GET    /bo/{projection}/valueHelp/{vh}      value help
POST   /bo/{projection}/{action}            custom action
GET    /view/{view}                         view route
GET    /view/{view}/meta                    view metadata
\`\`\`

## Removed (breaking)

- \`BOConfig.routePrefix\` + \`BusinessObjectDef.routePrefix\`
- \`ProjectionRouteConfig.prefix\`
- \`ViewRouteConfig.prefix\`
- \`BOMeta.routePrefix\`

## Why

- **Frontend simplicity** — with only the projection name the UI can build any URL. No catalog lookup needed for URLs.
- **Refactor safety** — renaming a projection rewrites every URL automatically; the frontend can't lag behind.
- **Multi-tenant routing stays in middleware** — API versioning, tenant prefixes, etc. belong in Fastify's encapsulation layer (\`app.register(routes, { prefix: '/v1' })\`), not on each BO.

## Migration

Replace per-BO / per-projection prefix configs with distinct projection names. Two projections over the same BO that shared a prefix must now pick distinct \`name\`s.

For tenant or version prefixes, wrap \`registerProjection\` in a Fastify plugin and use Fastify's \`prefix\`:

\`\`\`ts
app.register(async (api) => {
  registerProjection(api, db, { projection: warehouseProjection, ... })
}, { prefix: '/v1' })
// → /v1/bo/warehouse, /v1/meta/warehouse, etc.
\`\`\`

## Test plan

- [x] All existing test files updated to use \`/bo/{projection.name}\` URLs (no more \`/api/...\` paths)
- [x] \`route-prefix-collision.test.ts\` — \`/meta/{name}\` namespace still doesn't collide with \`/bo/{name}\`
- [x] \`projections.test.ts\` — multi-projection isolation works via distinct projection names (\`areaRead\` vs \`areaFull\`) instead of shared BO with different prefixes
- [x] All 477 tests pass (399 core + 78 fastify), lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)