### PR TITLE
feat: add @pgbo/client — framework-agnostic HTTP client (closes #46)

### DIFF
--- a/.changeset/pgbo-client.md
+++ b/.changeset/pgbo-client.md
@@ -1,0 +1,48 @@
+---
+"@pgbo/core": minor
+"@pgbo/client": minor
+---
+
+New package `@pgbo/client` — framework-agnostic HTTP client (closes #46).
+
+Before, every frontend that talked to a `@pgbo/fastify` server re-implemented the same plumbing: URL builders, pagination unwrap, metadata cache, auth refresh, locale handling. That logic now lives in one place, owned and tested by the framework.
+
+```typescript
+import { createClient } from '@pgbo/client'
+
+const pgbo = createClient({
+  baseUrl: 'http://localhost:3000',
+  locale: () => i18n.language,
+  getAuthHeader: () => `Bearer ${token}`,
+  refreshAuth: async () => `Bearer ${await refresh()}`,
+})
+
+await pgbo.list('warehouse', { search: 'main' })
+await pgbo.detail('warehouse', 'main')
+await pgbo.create('warehouse', { name: 'X' })
+await pgbo.update('warehouse', 'main', { name: 'Renamed' })
+await pgbo.action<Blob>('doc', 'pdf', { id: 1 }, { responseType: 'blob' })
+
+const meta = await pgbo.meta('warehouse')   // cached after first call
+const uoms = await pgbo.valueHelp('product', 'uom')   // unwrapped — already an array
+```
+
+### What's in the box
+
+- `createClient(config)` — full client with `meta`, `list`, `detail`, `create`, `update`, `delete`, `action`, `valueHelp`, `valueHelpPaged`, `view`, `viewPaged`, `viewMeta`, `invalidateMeta`
+- URL builders (`urlForProjection`, `urlForDetail`, `urlForAction`, `urlForValueHelp`, `urlForMeta`, `urlForView`, `urlForViewMeta`) + `buildQueryString`
+- Re-exported metadata/query types (`FieldMeta`, `BOMeta`, `ValueHelpRef`, `ListParams`, `PaginatedResult`, …) so frontends don't import the server package
+- `PublicBoMeta` / `PublicFieldMeta` / `PublicValueHelpRef` — typed response shapes after `@pgbo/fastify`'s `/meta` transform (labelKey populated, endpoints resolved to absolute URLs)
+- `PgboClientError` — thrown on non-2xx, with `status`, `url`, and parsed `body`
+- 401 retry once via `refreshAuth` callback
+- Per-projection metadata cache with `invalidateMeta(name?)` to bust
+
+### What's not in the box
+
+- Framework hooks (React / Vue / Svelte) — separate packages on top
+- UI components — app concern
+- Code-generated types — build-step concern
+
+### Companion change in `@pgbo/core`
+
+`@pgbo/core/metadata` now re-exports `AssociationMeta`, `CompositionMeta`, `ValueHelpMeta`, `FieldKind`, and `FilterOption` so `@pgbo/client` can re-export them cleanly.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,9 +64,11 @@ jobs:
         run: |
           npm publish --workspace @pgbo/core --provenance --access public --dry-run
           npm publish --workspace @pgbo/fastify --provenance --access public --dry-run
+          npm publish --workspace @pgbo/client --provenance --access public --dry-run
 
       # No NPM_TOKEN — authenticates via OIDC against npm's Trusted Publisher
-      # config for @pgbo/core and @pgbo/fastify. Requires id-token:write (above).
+      # config for @pgbo/core, @pgbo/fastify, and @pgbo/client. Requires
+      # id-token:write (above) and a Trusted Publisher entry per package on npm.
       - name: Publish to npm + create GitHub release
         if: inputs.dry-run != true
         uses: changesets/action@v1

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
         text: 'Adapters',
         items: [
           { text: '@pgbo/fastify', link: '/fastify' },
+          { text: '@pgbo/client', link: '/client' },
         ],
       },
     ],

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,231 @@
+# HTTP Client — `@pgbo/client`
+
+`@pgbo/client` is the framework-agnostic HTTP layer for pgbo. It owns the URL schema, pagination contract, metadata cache, and auth integration — so frontend code stops re-implementing them per project.
+
+No React, no Vue, no UI components — just `fetch` wrapped with the things every pgbo frontend needs.
+
+## Install
+
+```bash
+npm install @pgbo/client
+```
+
+The package re-exports the structural types from `@pgbo/core`, so frontends never import the server package (which pulls in `pg`).
+
+## Quick start
+
+```typescript
+import { createClient } from '@pgbo/client'
+
+const pgbo = createClient({
+  baseUrl: 'http://localhost:3000',
+  locale:  () => i18n.language,                    // appended as ?locale=...
+  getAuthHeader: () => `Bearer ${currentToken()}`,
+  refreshAuth:   async () => {
+    await refreshTokens()
+    return `Bearer ${currentToken()}`
+  },
+})
+
+// Metadata (cached after first call)
+const meta = await pgbo.meta('warehouseProduct')
+
+// CRUD
+const list = await pgbo.list('warehouseProduct', { page: 1, limit: 25, search: 'foo' })
+const item = await pgbo.detail('warehouseProduct', 'BB-8005')
+await pgbo.create('warehouseProduct', { wku: 'X', baseUomSlug: 'EA' })
+await pgbo.update('warehouseProduct', 'BB-8005', { baseUomSlug: 'PCS' })
+await pgbo.delete('warehouseProduct', 'BB-8005')
+
+// Custom action — JSON
+const result = await pgbo.action('stockDocument', 'post', { items: [/* … */] })
+
+// Custom action — binary (PDF / XLSX from a FileResponse)
+const blob = await pgbo.action<Blob>('stockDocument', 'pdf', { id }, { responseType: 'blob' })
+
+// Value-help dropdown — items unwrapped for direct use
+const uoms = await pgbo.valueHelp('warehouseProduct', 'uom')
+//   ↑ already an array of rows, no { items: [...] } wrapper
+```
+
+## URL schema (single source of truth)
+
+Every URL the client constructs flows through one of these helpers — when `@pgbo/fastify`'s URL layout changes (issue #44 locked it), the client follows automatically:
+
+| Helper | Pattern |
+|---|---|
+| `urlForProjection(base, name)` | `{base}/bo/{name}` |
+| `urlForDetail(base, name, paramValue)` | `{base}/bo/{name}/{paramValue}` |
+| `urlForAction(base, name, action)` | `{base}/bo/{name}/{action}` |
+| `urlForValueHelp(base, name, vh)` | `{base}/bo/{name}/valueHelp/{vh}` |
+| `urlForMeta(base, name)` | `{base}/meta/{name}` |
+| `urlForView(base, name)` | `{base}/view/{name}` |
+| `urlForViewMeta(base, name)` | `{base}/view/{name}/meta` |
+| `buildQueryString(params)` | `?key=value&filter.col=v&fields=a,b` |
+
+Param values get URL-encoded; `filters: { col: 'val' }` expands to `?filter.col=val`; arrays serialise as comma-joined values (matches `?fields=a,b,c`).
+
+## `createClient(config)` — full config reference
+
+```typescript
+interface ClientConfig {
+  /** API root, e.g. 'http://localhost:3000'. Trailing slash is fine. */
+  baseUrl: string
+  /** Override the global fetch — for testing, custom timeouts, mocks, etc. */
+  fetch?: typeof globalThis.fetch
+  /** Resolves the current locale on every request → ?locale=... */
+  locale?: () => string
+  /** Returns a value for the Authorization header on every request. */
+  getAuthHeader?: () => string | null | undefined | Promise<string | null | undefined>
+  /** Called once on a 401 response to refresh tokens; the request then retries with the new header. */
+  refreshAuth?: () => Promise<string | null | undefined>
+  /** Extra headers attached to every request (e.g. tenant ID, request ID). */
+  headers?: () => Record<string, string> | Promise<Record<string, string>>
+}
+```
+
+## `PgboClient` — methods
+
+```typescript
+interface PgboClient {
+  meta(projection: string): Promise<PublicBoMeta>
+  invalidateMeta(projection?: string): void
+
+  list<T>(projection: string, query?: ListQuery): Promise<PaginatedResult<T>>
+  detail<T>(projection: string, paramValue: string | number): Promise<T>
+  create<T>(projection: string, data: Record<string, unknown>): Promise<T>
+  update<T>(projection: string, paramValue: string | number, data: Record<string, unknown>): Promise<T>
+  delete<T>(projection: string, paramValue: string | number): Promise<T>
+
+  action<TOut>(projection: string, action: string, data?: Record<string, unknown>, options?: { responseType?: 'json' | 'blob' }): Promise<TOut>
+
+  valueHelp<T>(projection: string, vh: string, query?: ListQuery): Promise<T[]>          // unwrapped
+  valueHelpPaged<T>(projection: string, vh: string, query?: ListQuery): Promise<PaginatedResult<T>>
+
+  view<T>(view: string, query?: ListQuery): Promise<T[]>                                  // unwrapped
+  viewPaged<T>(view: string, query?: ListQuery): Promise<PaginatedResult<T>>
+  viewMeta(view: string): Promise<unknown>
+}
+```
+
+`ListQuery` mirrors the pgbo Fastify list contract:
+
+```typescript
+interface ListQuery {
+  page?: number                              // 1-based, default 1
+  limit?: number                             // default 25, max 250
+  search?: string                            // ?search= against searchable fields
+  sort?: string                              // ?sort=column
+  order?: 'asc' | 'desc'                     // default 'asc'
+  filters?: Record<string, string | number | boolean>  // ?filter.<col>=value
+  locale?: string                            // overrides config.locale()
+  fields?: readonly string[]                 // ?fields=a,b,c
+}
+```
+
+## Metadata cache
+
+`pgbo.meta(name)` returns a Promise; the resolved value is cached per BO name and shared between callers. Subsequent `pgbo.meta('warehouse')` calls hit the same Promise — no duplicate `/meta/warehouse` requests during a session.
+
+```typescript
+const a = await pgbo.meta('warehouse')
+const b = await pgbo.meta('warehouse')
+console.log(a === b)   // true — same object reference
+```
+
+Failed fetches are not cached — the next call retries.
+
+```typescript
+// Drop one entry — next .meta() refetches
+pgbo.invalidateMeta('warehouse')
+
+// Drop everything — useful after a logout/login cycle
+pgbo.invalidateMeta()
+```
+
+## Auth integration — `getAuthHeader` + `refreshAuth`
+
+```typescript
+const pgbo = createClient({
+  baseUrl,
+  getAuthHeader: () => `Bearer ${tokenStore.access}`,
+  refreshAuth:   async () => {
+    await refreshAccessToken()
+    return `Bearer ${tokenStore.access}`
+  },
+})
+```
+
+Flow:
+
+1. Every request reads `Authorization` from `getAuthHeader()`.
+2. If the response is **401**, the client calls `refreshAuth()` once.
+3. The original request is retried with the new header.
+4. If the retry also returns 401, the error propagates — no infinite loops.
+
+Refresh-token storage and expiry handling stay in the app (auth schemes vary too widely). The client just provides the retry-once hook.
+
+## Locale handling
+
+When `config.locale()` is set, every request appends `?locale=<value>`. Callers can override per-request:
+
+```typescript
+const pgbo = createClient({ baseUrl, locale: () => 'en' })
+
+await pgbo.list('warehouse')                    // /bo/warehouse?locale=en
+await pgbo.list('warehouse', { locale: 'de' })  // /bo/warehouse?locale=de
+```
+
+## Pagination unwrap
+
+| Method | Returns |
+|---|---|
+| `list()` | `PaginatedResult<T>` — UIs need `total` for paging widgets |
+| `detail()` | `T` |
+| `valueHelp()` | `T[]` — unwrapped, dropdowns rarely need totals |
+| `valueHelpPaged()` | `PaginatedResult<T>` — when a dropdown does need pagination (huge value helps) |
+| `view()` | `T[]` — unwrapped |
+| `viewPaged()` | `PaginatedResult<T>` |
+
+## Errors — `PgboClientError`
+
+Non-2xx responses throw `PgboClientError` with the parsed body attached:
+
+```typescript
+import { PgboClientError } from '@pgbo/client'
+
+try {
+  await pgbo.detail('warehouse', 'nonexistent')
+} catch (e) {
+  if (e instanceof PgboClientError) {
+    console.error(e.status, e.url, e.body)   // 404, full URL, parsed JSON body
+  }
+}
+```
+
+`PgboClientError.body` is whatever the server returned — for pgbo's standard 404/403 it's `{ error: 'Not found' }`; for custom action errors it's whatever your handler threw.
+
+## Re-exported types
+
+`@pgbo/client` re-exports the metadata/query types from `@pgbo/core` so frontends use a single import path:
+
+```typescript
+import type {
+  FieldMeta, FilterMeta, ValueHelpRef, ValueHelpMeta,
+  CompositionMeta, AssociationMeta, ViewMeta, BOMeta,
+  FieldKind, FilterOption,
+  ListParams, PaginatedResult,
+  PublicBoMeta, PublicFieldMeta, PublicFilterMeta, PublicValueHelpRef,
+} from '@pgbo/client'
+```
+
+The `Public*` variants are the response shapes after `@pgbo/fastify`'s `/meta/:name` transform (i.e. with `labelKey` populated and `valueHelp.endpoint` resolved to absolute URLs).
+
+## What `@pgbo/client` deliberately does NOT do
+
+- **No framework-specific bindings** — React hooks, Vue composables, Svelte stores belong in separate packages on top of this one.
+- **No UI components** — tables, forms, dropdowns are app concerns.
+- **No global state** — apps choose their own (Zustand, signals, query libraries, etc.). The metadata cache is local to each client instance.
+- **No code-generated types per BO** — that's a build-step concern and lives outside this package.
+
+The client is the wire layer. Everything above it is the app's call.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "vitepress": "^1.6.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1489,6 +1489,10 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pgbo/client": {
+      "resolved": "packages/pgbo-client",
+      "link": true
     },
     "node_modules/@pgbo/core": {
       "resolved": "packages/pgbo",
@@ -6165,7 +6169,7 @@
     },
     "packages/pgbo": {
       "name": "@pgbo/core",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "pg": "^8.16.0"
@@ -6183,7 +6187,7 @@
         "zod": "^4.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
@@ -6194,12 +6198,30 @@
         }
       }
     },
-    "packages/pgbo-fastify": {
-      "name": "@pgbo/fastify",
+    "packages/pgbo-client": {
+      "name": "@pgbo/client",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@pgbo/core": "0.1.0"
+        "@pgbo/core": "0.6.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.2.1",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.58.2",
+        "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/pgbo-fastify": {
+      "name": "@pgbo/fastify",
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@pgbo/core": "0.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -6210,7 +6232,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "fastify": "^5.0.0"

--- a/packages/pgbo-client/LICENSE
+++ b/packages/pgbo-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tim Riep <tim@riep-tech.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pgbo-client/README.md
+++ b/packages/pgbo-client/README.md
@@ -1,0 +1,31 @@
+# @pgbo/client
+
+Framework-agnostic HTTP client for [pgbo](https://github.com/tim-riep/pgbo). Wraps `fetch` with the things every pgbo frontend needs:
+
+- URL composition (single source of truth for the `/bo/{name}` schema)
+- Pagination unwrap
+- Metadata cache
+- 401 retry via configurable `refreshAuth`
+- Locale + custom-header pass-through
+- Re-exported types from `@pgbo/core` (so frontends never import the server package)
+
+```ts
+import { createClient } from '@pgbo/client'
+
+const pgbo = createClient({
+  baseUrl: 'http://localhost:3000',
+  locale: () => 'en',
+  getAuthHeader: () => `Bearer ${token}`,
+})
+
+await pgbo.list('warehouse', { search: 'main' })
+await pgbo.create('warehouse', { name: 'X' })
+await pgbo.action<Blob>('doc', 'pdf', { id: 1 }, { responseType: 'blob' })
+const uoms = await pgbo.valueHelp('product', 'uom')
+```
+
+Full reference: https://tim-riep.github.io/pgbo/client
+
+## License
+
+MIT

--- a/packages/pgbo-client/eslint.config.js
+++ b/packages/pgbo-client/eslint.config.js
@@ -1,0 +1,47 @@
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-invalid-void-type': 'off',
+      '@typescript-eslint/consistent-type-definitions': 'off',
+      '@typescript-eslint/prefer-regexp-exec': 'off',
+      '@typescript-eslint/prefer-for-of': 'off',
+      '@typescript-eslint/no-unnecessary-type-arguments': 'off',
+      '@typescript-eslint/dot-notation': 'off',
+      '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true, allowBoolean: true }],
+    },
+  },
+  {
+    files: ['tests/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-expressions': 'off',
+      '@typescript-eslint/no-deprecated': 'off',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/array-type': 'off',
+    },
+  },
+)

--- a/packages/pgbo-client/package.json
+++ b/packages/pgbo-client/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@pgbo/client",
+  "version": "0.1.0",
+  "description": "Framework-agnostic HTTP client for pgbo — URL composition, typed fetch, metadata cache",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src tests"
+  },
+  "keywords": [
+    "pgbo",
+    "client",
+    "fetch",
+    "http",
+    "metadata",
+    "frontend",
+    "business-objects"
+  ],
+  "author": "Tim Riep <tim@riep-tech.de>",
+  "license": "MIT",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tim-riep/pgbo.git",
+    "directory": "packages/pgbo-client"
+  },
+  "bugs": {
+    "url": "https://github.com/tim-riep/pgbo/issues"
+  },
+  "homepage": "https://github.com/tim-riep/pgbo#readme",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@pgbo/core": "0.6.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.2.1",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.58.2",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/pgbo-client/src/client.ts
+++ b/packages/pgbo-client/src/client.ts
@@ -1,0 +1,229 @@
+// HTTP client for pgbo (issue #46). Framework-agnostic — wraps `fetch`, knows
+// pgbo's URL schema and pagination contract, caches metadata, retries once on 401.
+
+import type {
+  PaginatedResult,
+} from '@pgbo/core/query'
+import {
+  urlForProjection, urlForDetail, urlForAction, urlForValueHelp,
+  urlForMeta, urlForView, urlForViewMeta, buildQueryString,
+} from './urls.js'
+import type {
+  ClientConfig, ListQuery, PublicBoMeta, ActionOptions,
+} from './types.js'
+import { PgboClientError } from './types.js'
+
+/** Public client surface returned by `createClient`. */
+export interface PgboClient {
+  /** GET `/meta/{name}` — cached. Subsequent calls return the same Promise. */
+  meta(projection: string): Promise<PublicBoMeta>
+  /** Drop the cached metadata for a projection so the next `meta()` re-fetches. */
+  invalidateMeta(projection?: string): void
+
+  /** GET `/bo/{name}` — paginated list with `{ items, total, page, limit }`. */
+  list<T = Record<string, unknown>>(projection: string, query?: ListQuery): Promise<PaginatedResult<T>>
+
+  /** GET `/bo/{name}/{paramValue}` — single row. */
+  detail<T = Record<string, unknown>>(projection: string, paramValue: string | number): Promise<T>
+
+  /** POST `/bo/{name}` — returns the created row. */
+  create<T = Record<string, unknown>>(projection: string, data: Record<string, unknown>): Promise<T>
+
+  /** PUT `/bo/{name}/{paramValue}` — returns the updated row. */
+  update<T = Record<string, unknown>>(
+    projection: string,
+    paramValue: string | number,
+    data: Record<string, unknown>,
+  ): Promise<T>
+
+  /** DELETE `/bo/{name}/{paramValue}`. */
+  delete<T = Record<string, unknown>>(projection: string, paramValue: string | number): Promise<T>
+
+  /**
+   * POST `/bo/{name}/{action}` — custom action.
+   * Set `responseType: 'blob'` for binary returns (e.g. PDF / XLSX from `FileResponse`).
+   */
+  action<TOut = unknown>(
+    projection: string,
+    action: string,
+    data?: Record<string, unknown>,
+    options?: ActionOptions,
+  ): Promise<TOut>
+
+  /**
+   * GET `/bo/{name}/valueHelp/{vh}` — paginated dropdown source. Returns the
+   * unwrapped `items` array (callers usually only need the rows). Use
+   * `valueHelpPaged` if you need the full pagination envelope.
+   */
+  valueHelp<T = Record<string, unknown>>(projection: string, vh: string, query?: ListQuery): Promise<T[]>
+
+  /** Same as `valueHelp` but returns the full `{ items, total, page, limit }` envelope. */
+  valueHelpPaged<T = Record<string, unknown>>(
+    projection: string,
+    vh: string,
+    query?: ListQuery,
+  ): Promise<PaginatedResult<T>>
+
+  /** GET `/view/{name}` — read-only view route. Unwraps `items`. */
+  view<T = Record<string, unknown>>(view: string, query?: ListQuery): Promise<T[]>
+
+  /** Same as `view` but returns the full pagination envelope. */
+  viewPaged<T = Record<string, unknown>>(view: string, query?: ListQuery): Promise<PaginatedResult<T>>
+
+  /** GET `/view/{name}/meta` — view-route metadata. */
+  viewMeta(view: string): Promise<unknown>
+}
+
+/** Create a configured pgbo HTTP client. */
+export function createClient(config: ClientConfig): PgboClient {
+  const fetchImpl = config.fetch ?? globalThis.fetch.bind(globalThis)
+  const metaCache = new Map<string, Promise<PublicBoMeta>>()
+
+  /** Resolve dynamic header values (auth + locale + extras) into a flat record. */
+  async function buildHeaders(): Promise<Record<string, string>> {
+    const headers: Record<string, string> = { 'content-type': 'application/json' }
+    if (config.getAuthHeader) {
+      const auth = await config.getAuthHeader()
+      if (auth) headers.authorization = auth
+    }
+    if (config.headers) {
+      Object.assign(headers, await config.headers())
+    }
+    return headers
+  }
+
+  /** Apply the `?locale=` shortcut from `config.locale` unless the caller already set it. */
+  function applyLocale(query: ListQuery | undefined): ListQuery {
+    if (query?.locale !== undefined) return query
+    const locale = config.locale?.()
+    if (!locale) return query ?? {}
+    return { ...query, locale }
+  }
+
+  /** Run a request, retrying once on 401 if `refreshAuth` is configured. */
+  async function request(
+    url: string,
+    init: { method: string; body?: BodyInit | null },
+    responseType: 'json' | 'blob' | 'none' = 'json',
+  ): Promise<unknown> {
+    const headers = await buildHeaders()
+    let res = await fetchImpl(url, { ...init, headers })
+
+    if (res.status === 401 && config.refreshAuth) {
+      const newAuth = await config.refreshAuth()
+      const retryHeaders: Record<string, string> = { ...headers }
+      if (newAuth) retryHeaders.authorization = newAuth
+      else delete retryHeaders.authorization
+      res = await fetchImpl(url, { ...init, headers: retryHeaders })
+    }
+
+    if (!res.ok) {
+      let body: unknown
+      try {
+        body = await res.json() as unknown
+      } catch { /* non-JSON error body */ }
+      throw new PgboClientError(
+        `pgbo: ${init.method} ${url} failed with ${res.status}`,
+        res.status, url, body,
+      )
+    }
+
+    if (responseType === 'none' || res.status === 204) return undefined
+    if (responseType === 'blob') return res.blob()
+    return res.json() as Promise<unknown>
+  }
+
+  function get(url: string, responseType: 'json' | 'blob' = 'json'): Promise<unknown> {
+    return request(url, { method: 'GET' }, responseType)
+  }
+  function post(url: string, body?: unknown, responseType: 'json' | 'blob' | 'none' = 'json'): Promise<unknown> {
+    const init: { method: string; body?: BodyInit | null } = { method: 'POST' }
+    if (body !== undefined) init.body = JSON.stringify(body)
+    return request(url, init, responseType)
+  }
+  function put(url: string, body: unknown): Promise<unknown> {
+    return request(url, { method: 'PUT', body: JSON.stringify(body) })
+  }
+  function del(url: string): Promise<unknown> {
+    return request(url, { method: 'DELETE' })
+  }
+
+  return {
+    meta(projection) {
+      let pending = metaCache.get(projection)
+      if (!pending) {
+        pending = (get(urlForMeta(config.baseUrl, projection)) as Promise<PublicBoMeta>)
+          .catch((err: unknown) => {
+            metaCache.delete(projection)  // don't cache failures
+            throw err
+          })
+        metaCache.set(projection, pending)
+      }
+      return pending
+    },
+
+    invalidateMeta(projection) {
+      if (projection) metaCache.delete(projection)
+      else metaCache.clear()
+    },
+
+    async list<T>(projection: string, query?: ListQuery) {
+      const qs = buildQueryString(applyLocale(query) as Record<string, unknown>)
+      return await get(`${urlForProjection(config.baseUrl, projection)}${qs}`) as PaginatedResult<T>
+    },
+
+    async detail<T>(projection: string, paramValue: string | number) {
+      const qs = buildQueryString(applyLocale(undefined) as Record<string, unknown>)
+      return await get(`${urlForDetail(config.baseUrl, projection, paramValue)}${qs}`) as T
+    },
+
+    async create<T>(projection: string, data: Record<string, unknown>) {
+      return await post(urlForProjection(config.baseUrl, projection), data) as T
+    },
+
+    async update<T>(projection: string, paramValue: string | number, data: Record<string, unknown>) {
+      return await put(urlForDetail(config.baseUrl, projection, paramValue), data) as T
+    },
+
+    async delete<T>(projection: string, paramValue: string | number) {
+      return await del(urlForDetail(config.baseUrl, projection, paramValue)) as T
+    },
+
+    async action<TOut>(
+      projection: string,
+      action: string,
+      data?: Record<string, unknown>,
+      options?: ActionOptions,
+    ) {
+      return await post(
+        urlForAction(config.baseUrl, projection, action),
+        data,
+        options?.responseType ?? 'json',
+      ) as TOut
+    },
+
+    async valueHelp<T>(projection: string, vh: string, query?: ListQuery) {
+      const result = await this.valueHelpPaged<T>(projection, vh, query)
+      return [...result.items]
+    },
+
+    async valueHelpPaged<T>(projection: string, vh: string, query?: ListQuery) {
+      const qs = buildQueryString(applyLocale(query) as Record<string, unknown>)
+      return await get(`${urlForValueHelp(config.baseUrl, projection, vh)}${qs}`) as PaginatedResult<T>
+    },
+
+    async view<T>(view: string, query?: ListQuery) {
+      const result = await this.viewPaged<T>(view, query)
+      return [...result.items]
+    },
+
+    async viewPaged<T>(view: string, query?: ListQuery) {
+      const qs = buildQueryString(applyLocale(query) as Record<string, unknown>)
+      return await get(`${urlForView(config.baseUrl, view)}${qs}`) as PaginatedResult<T>
+    },
+
+    async viewMeta(view: string) {
+      return await get(urlForViewMeta(config.baseUrl, view))
+    },
+  }
+}

--- a/packages/pgbo-client/src/index.ts
+++ b/packages/pgbo-client/src/index.ts
@@ -1,0 +1,26 @@
+// Public surface of @pgbo/client.
+//
+// Apps interact with pgbo over HTTP through `createClient(config)` and use the
+// re-exported types from `@pgbo/core` for typing — no need to import the
+// server-only `@pgbo/core` directly from frontend code.
+
+export { createClient } from './client.js'
+export type { PgboClient } from './client.js'
+
+export {
+  urlForProjection, urlForDetail, urlForAction,
+  urlForValueHelp, urlForMeta, urlForView, urlForViewMeta,
+  buildQueryString,
+} from './urls.js'
+
+export {
+  PgboClientError,
+} from './types.js'
+export type {
+  ClientConfig, ListQuery, ActionOptions,
+  PublicBoMeta, PublicFieldMeta, PublicFilterMeta, PublicValueHelpRef,
+  // Re-exports from @pgbo/core
+  FieldMeta, FilterMeta, ValueHelpRef, ValueHelpMeta, CompositionMeta, AssociationMeta,
+  ViewMeta, BOMeta, FieldKind, FilterOption,
+  ListParams, PaginatedResult,
+} from './types.js'

--- a/packages/pgbo-client/src/types.ts
+++ b/packages/pgbo-client/src/types.ts
@@ -1,0 +1,126 @@
+// Re-export structural types from @pgbo/core so frontend bundles don't have to
+// transitively import the server package (which pulls in `pg`, `@types/pg`, …).
+//
+// These are pure types with no runtime dependency. Browser bundlers tree-shake
+// them away. Apps treat `@pgbo/client` as the single import point for frontend code.
+
+export type {
+  FieldMeta,
+  FilterMeta,
+  ValueHelpRef,
+  ValueHelpMeta,
+  CompositionMeta,
+  AssociationMeta,
+  ViewMeta,
+  BOMeta,
+  FieldKind,
+  FilterOption,
+} from '@pgbo/core/metadata'
+
+export type {
+  ListParams,
+  PaginatedResult,
+} from '@pgbo/core/query'
+
+/**
+ * The `/meta/:name` response shape returned by `@pgbo/fastify`. Same as `BOMeta`
+ * but with `label` already transformed to `labelKey` (always set, with the
+ * `${projection.name}.${key}` fallback baked in) and `valueHelp.endpoint` /
+ * `filterable.endpoint` resolved to absolute URLs (issue #35).
+ */
+export interface PublicFieldMeta {
+  readonly key: string
+  readonly kind: 'text' | 'number' | 'date' | 'boolean' | 'slug' | 'relation' | 'translation'
+  readonly labelKey: string
+  readonly hidden: boolean
+  readonly immutable: boolean
+  readonly searchable: boolean
+  readonly filterable: false | PublicFilterMeta
+  readonly valueHelp?: PublicValueHelpRef
+  readonly inList: boolean
+  readonly inForm: boolean
+  readonly required: boolean
+  readonly quick: boolean
+}
+
+export interface PublicFilterMeta {
+  readonly type: 'text' | 'date' | 'select' | 'relation'
+  readonly endpoint?: string
+  readonly valueField?: string
+  readonly labelField?: string
+  readonly options?: readonly { value: string; label: string }[]
+}
+
+export interface PublicValueHelpRef {
+  readonly name: string
+  readonly endpoint: string
+  readonly keyField: string
+  readonly displayField: string
+}
+
+export interface PublicBoMeta {
+  readonly name: string
+  readonly paramField: string
+  readonly readOnly: boolean
+  readonly fields: readonly PublicFieldMeta[]
+  readonly associations: readonly { name: string; foreignKey: string; target?: string }[]
+  readonly compositions: readonly { name: string; fields: readonly string[] }[]
+  readonly valueHelps: readonly { name: string; fields: readonly PublicFieldMeta[] }[]
+  readonly orderBy?: string
+  readonly orderDir?: 'asc' | 'desc'
+  readonly cacheTags?: readonly string[]
+}
+
+/** Query options for `client.list` / `client.valueHelp` / view routes. */
+export interface ListQuery {
+  readonly page?: number
+  readonly limit?: number
+  readonly search?: string
+  readonly sort?: string
+  readonly order?: 'asc' | 'desc'
+  /** `?filter.<col>=value` — pgbo's per-column filter convention. */
+  readonly filters?: Readonly<Record<string, string | number | boolean>>
+  readonly locale?: string
+  /** Comma-joined into `?fields=a,b,c`. */
+  readonly fields?: readonly string[]
+}
+
+/** Configuration passed to `createClient`. */
+export interface ClientConfig {
+  /** API root, e.g. `'http://localhost:3000'`. Trailing slash is fine. */
+  readonly baseUrl: string
+  /** Override the global `fetch` (for testing, custom timeouts, etc.). */
+  readonly fetch?: typeof globalThis.fetch
+  /** Resolves the current locale on every request — appended as `?locale=...`. */
+  readonly locale?: () => string
+  /** Returns a value for the `Authorization` header on every request. */
+  readonly getAuthHeader?: () => string | null | undefined | Promise<string | null | undefined>
+  /**
+   * Called once on a 401 response to refresh tokens, then the request retries.
+   * Return the new `Authorization` header value to use on the retry.
+   */
+  readonly refreshAuth?: () => Promise<string | null | undefined>
+  /** Extra headers attached to every request (e.g. `'X-Tenant-Id'`). */
+  readonly headers?: () => Record<string, string> | Promise<Record<string, string>>
+}
+
+/** Raised on non-2xx responses. */
+export class PgboClientError extends Error {
+  readonly status: number
+  readonly url: string
+  readonly body: unknown
+
+  constructor(message: string, status: number, url: string, body: unknown) {
+    super(message)
+    this.name = 'PgboClientError'
+    this.status = status
+    this.url = url
+    this.body = body
+  }
+}
+
+/** Options for `client.action` — used to opt into binary responses. */
+export interface ActionOptions {
+  /** Default 'json'. Use 'blob' for binary returns (FileResponse on the server side). */
+  readonly responseType?: 'json' | 'blob'
+}

--- a/packages/pgbo-client/src/urls.ts
+++ b/packages/pgbo-client/src/urls.ts
@@ -1,0 +1,78 @@
+// Single source of truth for the pgbo URL schema (issues #44 + #46).
+// Every URL constructed by `@pgbo/client` flows through these helpers — when
+// `@pgbo/fastify`'s URL layout changes, this file is the only thing to update.
+
+/** Strip a single trailing slash so `${base}/${path}` doesn't double-up. */
+function trimBase(base: string): string {
+  return base.endsWith('/') ? base.slice(0, -1) : base
+}
+
+/** `${base}/bo/{projection}` — list / create endpoint. */
+export function urlForProjection(base: string, projection: string): string {
+  return `${trimBase(base)}/bo/${projection}`
+}
+
+/** `${base}/bo/{projection}/{paramValue}` — detail / update / delete endpoint. */
+export function urlForDetail(base: string, projection: string, paramValue: string | number): string {
+  return `${trimBase(base)}/bo/${projection}/${encodeURIComponent(String(paramValue))}`
+}
+
+/** `${base}/bo/{projection}/{action}` — custom action endpoint. */
+export function urlForAction(base: string, projection: string, action: string): string {
+  return `${trimBase(base)}/bo/${projection}/${encodeURIComponent(action)}`
+}
+
+/** `${base}/bo/{projection}/valueHelp/{vh}` — value-help dropdown source. */
+export function urlForValueHelp(base: string, projection: string, vh: string): string {
+  return `${trimBase(base)}/bo/${projection}/valueHelp/${encodeURIComponent(vh)}`
+}
+
+/** `${base}/meta/{projection}` — projection metadata. */
+export function urlForMeta(base: string, projection: string): string {
+  return `${trimBase(base)}/meta/${projection}`
+}
+
+/** `${base}/view/{view}` — read-only view route from `registerViewRoute`. */
+export function urlForView(base: string, view: string): string {
+  return `${trimBase(base)}/view/${view}`
+}
+
+/** `${base}/view/{view}/meta` — view metadata. */
+export function urlForViewMeta(base: string, view: string): string {
+  return `${trimBase(base)}/view/${view}/meta`
+}
+
+/** Encode a record into `key=value&key=value` (skipping undefined / null / empty strings).
+ * Preserves the `filter.<col>=value` convention pgbo uses for per-column filters. */
+export function buildQueryString(params: Record<string, unknown>): string {
+  const parts: string[] = []
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue
+    if (typeof value === 'string' && value === '') continue
+    if (typeof value === 'object') {
+      // filter.<col> shorthand: { filters: { col: 'val' } } → filter.col=val
+      if (key === 'filters') {
+        for (const [col, val] of Object.entries(value as Record<string, unknown>)) {
+          if (val === undefined || val === null || val === '') continue
+          if (typeof val === 'object') continue  // skip non-primitive values
+          const str = typeof val === 'string' ? val : String(val as number | boolean | bigint)
+          parts.push(`filter.${encodeURIComponent(col)}=${encodeURIComponent(str)}`)
+        }
+        continue
+      }
+      // Arrays — join with comma (matches `fields=id,slug,name` convention)
+      if (Array.isArray(value)) {
+        if (value.length > 0) {
+          const joined = (value as readonly unknown[]).map(v => String(v as string | number | boolean)).join(',')
+          parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(joined)}`)
+        }
+        continue
+      }
+      // Other objects — skip (caller should pre-serialize)
+      continue
+    }
+    const str = typeof value === 'string' ? value : String(value as number | boolean | bigint)
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(str)}`)
+  }
+  return parts.length > 0 ? `?${parts.join('&')}` : ''
+}

--- a/packages/pgbo-client/tests/client.test.ts
+++ b/packages/pgbo-client/tests/client.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createClient, PgboClientError } from '../src/index.js'
+
+/** Minimal Response stub backed by a body + status. */
+function jsonResponse(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  })
+}
+
+function errorResponse(status: number, body: unknown = { error: 'oops' }): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function blobResponse(bytes: Uint8Array, contentType: string): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: { 'content-type': contentType },
+  })
+}
+
+describe('createClient — request basics', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+  })
+
+  it('list returns the paginated envelope', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: [{ id: 1 }, { id: 2 }], total: 2, page: 1, limit: 25 }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const res = await client.list('warehouse', { page: 1, limit: 25 })
+    expect(res.items).toHaveLength(2)
+    expect(res.total).toBe(2)
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://api/bo/warehouse?page=1&limit=25')
+  })
+
+  it('detail issues GET to /bo/{name}/{paramValue}', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, name: 'Main' }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    await client.detail('warehouse', 'main')
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://api/bo/warehouse/main')
+    expect(fetchMock.mock.calls[0]![1].method).toBe('GET')
+  })
+
+  it('create posts JSON body and returns the new row', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 99, name: 'X' }, { status: 201 }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const res = await client.create('warehouse', { name: 'X' })
+    expect(res).toEqual({ id: 99, name: 'X' })
+    const call = fetchMock.mock.calls[0]!
+    expect(call[1].method).toBe('POST')
+    expect(call[1].body).toBe(JSON.stringify({ name: 'X' }))
+    expect(call[1].headers['content-type']).toBe('application/json')
+  })
+
+  it('update + delete hit the correct verbs', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, name: 'Renamed' }))
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1 }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    await client.update('warehouse', 'main', { name: 'Renamed' })
+    await client.delete('warehouse', 'main')
+    expect(fetchMock.mock.calls[0]![1].method).toBe('PUT')
+    expect(fetchMock.mock.calls[1]![1].method).toBe('DELETE')
+  })
+
+  it('throws PgboClientError on non-2xx with the parsed body attached', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404, { error: 'Not found' }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    try {
+      await client.detail('warehouse', 'x')
+      throw new Error('should not reach here')
+    } catch (e) {
+      expect(e).toBeInstanceOf(PgboClientError)
+      const err = e as PgboClientError
+      expect(err.status).toBe(404)
+      expect(err.url).toBe('http://api/bo/warehouse/x')
+      expect(err.body).toEqual({ error: 'Not found' })
+    }
+  })
+})
+
+describe('createClient — meta cache', () => {
+  it('caches the same projection name across calls', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ name: 'warehouse', fields: [], paramField: 'id', readOnly: false, associations: [], compositions: [], valueHelps: [] }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const a = await client.meta('warehouse')
+    const b = await client.meta('warehouse')
+    expect(a).toBe(b)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidateMeta(name) drops a single entry', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ name: 'a', fields: [], paramField: 'id', readOnly: false, associations: [], compositions: [], valueHelps: [] }))
+      .mockResolvedValueOnce(jsonResponse({ name: 'a', fields: [{ key: 'x' }], paramField: 'id', readOnly: false, associations: [], compositions: [], valueHelps: [] }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    await client.meta('a')
+    client.invalidateMeta('a')
+    const second = await client.meta('a')
+    expect(second.fields).toHaveLength(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidateMeta() with no arg clears every entry', async () => {
+    const body = { name: 'x', fields: [], paramField: 'id', readOnly: false, associations: [], compositions: [], valueHelps: [] }
+    // Each call must produce a fresh Response — Response bodies are single-use
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse(body)))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    await Promise.all([client.meta('a'), client.meta('b')])
+    client.invalidateMeta()
+    await Promise.all([client.meta('a'), client.meta('b')])
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not cache failed fetches', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(errorResponse(500))
+      .mockResolvedValueOnce(jsonResponse({ name: 'x', fields: [], paramField: 'id', readOnly: false, associations: [], compositions: [], valueHelps: [] }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    await expect(client.meta('x')).rejects.toBeInstanceOf(PgboClientError)
+    const second = await client.meta('x')
+    expect(second.name).toBe('x')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('createClient — auth integration', () => {
+  it('attaches Authorization from getAuthHeader', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ items: [], total: 0, page: 1, limit: 25 }))
+    const client = createClient({
+      baseUrl: 'http://api',
+      fetch: fetchMock as unknown as typeof fetch,
+      getAuthHeader: () => 'Bearer abc',
+    })
+    await client.list('w')
+    expect(fetchMock.mock.calls[0]![1].headers.authorization).toBe('Bearer abc')
+  })
+
+  it('retries once on 401 after refreshAuth', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(errorResponse(401))
+      .mockResolvedValueOnce(jsonResponse({ items: [], total: 0, page: 1, limit: 25 }))
+    const refreshAuth = vi.fn().mockResolvedValue('Bearer fresh')
+    const client = createClient({
+      baseUrl: 'http://api',
+      fetch: fetchMock as unknown as typeof fetch,
+      getAuthHeader: () => 'Bearer stale',
+      refreshAuth,
+    })
+    await client.list('w')
+    expect(refreshAuth).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[1]![1].headers.authorization).toBe('Bearer fresh')
+  })
+
+  it('does not retry beyond a single attempt', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(errorResponse(401))
+      .mockResolvedValueOnce(errorResponse(401))
+    const client = createClient({
+      baseUrl: 'http://api',
+      fetch: fetchMock as unknown as typeof fetch,
+      getAuthHeader: () => 'Bearer x',
+      refreshAuth: () => Promise.resolve('Bearer y'),
+    })
+    await expect(client.list('w')).rejects.toMatchObject({ status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(2)  // initial + one retry, no more
+  })
+})
+
+describe('createClient — locale', () => {
+  it('appends ?locale= when config.locale is set and caller did not provide one', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ items: [], total: 0, page: 1, limit: 25 }))
+    const client = createClient({
+      baseUrl: 'http://api',
+      fetch: fetchMock as unknown as typeof fetch,
+      locale: () => 'de',
+    })
+    await client.list('w')
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://api/bo/w?locale=de')
+  })
+
+  it('explicit query.locale wins over config.locale()', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ items: [], total: 0, page: 1, limit: 25 }))
+    const client = createClient({
+      baseUrl: 'http://api',
+      fetch: fetchMock as unknown as typeof fetch,
+      locale: () => 'de',
+    })
+    await client.list('w', { locale: 'fr' })
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://api/bo/w?locale=fr')
+  })
+})
+
+describe('createClient — value helps and view routes', () => {
+  it('valueHelp unwraps items', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ items: [{ slug: 'kg' }, { slug: 'm' }], total: 2, page: 1, limit: 25 }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const rows = await client.valueHelp('product', 'uom')
+    expect(rows).toEqual([{ slug: 'kg' }, { slug: 'm' }])
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://api/bo/product/valueHelp/uom')
+  })
+
+  it('valueHelpPaged returns the full envelope', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ items: [{ slug: 'kg' }], total: 1, page: 2, limit: 10 }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const res = await client.valueHelpPaged('product', 'uom', { page: 2, limit: 10 })
+    expect(res.total).toBe(1)
+    expect(res.page).toBe(2)
+  })
+
+  it('view route + view meta', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ items: [{ a: 1 }], total: 1, page: 1, limit: 25 }))
+      .mockResolvedValueOnce(jsonResponse({ name: 'v', fields: [] }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    expect(await client.view('warehouse_view')).toEqual([{ a: 1 }])
+    expect(await client.viewMeta('warehouse_view')).toEqual({ name: 'v', fields: [] })
+    expect(fetchMock.mock.calls[1]![0]).toBe('http://api/view/warehouse_view/meta')
+  })
+})
+
+describe('createClient — actions', () => {
+  it('action posts JSON and returns parsed JSON by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ ok: true }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const res = await client.action('doc', 'archive', { id: 1 })
+    expect(res).toEqual({ ok: true })
+    expect(fetchMock.mock.calls[0]![0]).toBe('http://api/bo/doc/archive')
+    expect(fetchMock.mock.calls[0]![1].body).toBe(JSON.stringify({ id: 1 }))
+  })
+
+  it('action with responseType:"blob" returns a Blob', async () => {
+    const bytes = new Uint8Array([1, 2, 3])
+    const fetchMock = vi.fn().mockResolvedValueOnce(blobResponse(bytes, 'application/pdf'))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    const res = await client.action<Record<string, unknown>, Blob>('doc', 'pdf', { id: 1 }, { responseType: 'blob' })
+    expect(res).toBeInstanceOf(Blob)
+    const buf = await res.arrayBuffer()
+    expect(new Uint8Array(buf)).toEqual(bytes)
+  })
+
+  it('action with no body still issues a POST', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ ok: true }))
+    const client = createClient({ baseUrl: 'http://api', fetch: fetchMock as unknown as typeof fetch })
+    await client.action('doc', 'noop')
+    const init = fetchMock.mock.calls[0]![1]
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeUndefined()
+  })
+})
+
+describe('createClient — extra headers', () => {
+  it('merges per-request headers from config.headers()', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ items: [], total: 0, page: 1, limit: 25 }))
+    const client = createClient({
+      baseUrl: 'http://api',
+      fetch: fetchMock as unknown as typeof fetch,
+      headers: () => ({ 'x-tenant-id': 't1' }),
+    })
+    await client.list('w')
+    expect(fetchMock.mock.calls[0]![1].headers['x-tenant-id']).toBe('t1')
+  })
+})

--- a/packages/pgbo-client/tests/urls.test.ts
+++ b/packages/pgbo-client/tests/urls.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  urlForProjection, urlForDetail, urlForAction, urlForValueHelp,
+  urlForMeta, urlForView, urlForViewMeta, buildQueryString,
+} from '../src/urls.js'
+
+describe('URL builders', () => {
+  const base = 'http://localhost:3000'
+
+  it('urlForProjection', () => {
+    expect(urlForProjection(base, 'warehouse')).toBe('http://localhost:3000/bo/warehouse')
+  })
+
+  it('urlForDetail encodes the param value', () => {
+    expect(urlForDetail(base, 'warehouse', 'main')).toBe('http://localhost:3000/bo/warehouse/main')
+    expect(urlForDetail(base, 'warehouse', 'has space')).toBe('http://localhost:3000/bo/warehouse/has%20space')
+    expect(urlForDetail(base, 'product', 42)).toBe('http://localhost:3000/bo/product/42')
+  })
+
+  it('urlForAction encodes the action segment', () => {
+    expect(urlForAction(base, 'doc', 'pdf')).toBe('http://localhost:3000/bo/doc/pdf')
+  })
+
+  it('urlForValueHelp', () => {
+    expect(urlForValueHelp(base, 'product', 'uom')).toBe('http://localhost:3000/bo/product/valueHelp/uom')
+  })
+
+  it('urlForMeta', () => {
+    expect(urlForMeta(base, 'warehouse')).toBe('http://localhost:3000/meta/warehouse')
+  })
+
+  it('urlForView + urlForViewMeta', () => {
+    expect(urlForView(base, 'warehouse_view')).toBe('http://localhost:3000/view/warehouse_view')
+    expect(urlForViewMeta(base, 'warehouse_view')).toBe('http://localhost:3000/view/warehouse_view/meta')
+  })
+
+  it('strips a single trailing slash from baseUrl', () => {
+    expect(urlForProjection('http://x/', 'p')).toBe('http://x/bo/p')
+    expect(urlForProjection('http://x', 'p')).toBe('http://x/bo/p')
+  })
+})
+
+describe('buildQueryString', () => {
+  it('returns empty string for no params', () => {
+    expect(buildQueryString({})).toBe('')
+    expect(buildQueryString({ a: undefined, b: null, c: '' })).toBe('')
+  })
+
+  it('encodes simple primitives', () => {
+    expect(buildQueryString({ page: 2, limit: 25, search: 'foo' })).toBe('?page=2&limit=25&search=foo')
+  })
+
+  it('expands `filters` to filter.<col>=<val>', () => {
+    expect(buildQueryString({ filters: { active: true, slug: 'main' } })).toBe('?filter.active=true&filter.slug=main')
+  })
+
+  it('joins arrays with comma', () => {
+    expect(buildQueryString({ fields: ['id', 'slug', 'name'] })).toBe('?fields=id%2Cslug%2Cname')
+  })
+
+  it('skips undefined / null filter values', () => {
+    expect(buildQueryString({ filters: { a: 'x', b: undefined, c: null, d: '' } })).toBe('?filter.a=x')
+  })
+
+  it('encodes special characters', () => {
+    expect(buildQueryString({ search: 'foo bar&baz' })).toBe('?search=foo%20bar%26baz')
+  })
+})

--- a/packages/pgbo-client/tsconfig.eslint.json
+++ b/packages/pgbo-client/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "tests", "eslint.config.js", "vitest.config.ts"]
+}

--- a/packages/pgbo-client/tsconfig.json
+++ b/packages/pgbo-client/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/pgbo-client/vitest.config.ts
+++ b/packages/pgbo-client/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+})

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -23,7 +23,8 @@ import { toCamelCase } from '../query/select.js'
 import { getI18nConfig } from '../schema/i18n.js'
 import type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig, ValueHelpRef } from './types.js'
 
-export type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig, ValueHelpRef } from './types.js'
+export type { FieldMeta, FilterMeta, ViewMeta, BOMeta, TranslationConfig, EnrichConfig, ValueHelpRef, AssociationMeta, CompositionMeta, ValueHelpMeta } from './types.js'
+export type { FieldKind, FilterOption } from '../schema/definitions.js'
 
 // --- Kind inference ---
 


### PR DESCRIPTION
## Summary

New published package that owns the wire-protocol layer for any frontend talking to a \`@pgbo/fastify\` server. Apps stop re-implementing URL builders, pagination unwrap, metadata cache, and 401 retry plumbing per project.

\`\`\`ts
import { createClient } from '@pgbo/client'

const pgbo = createClient({
  baseUrl: 'http://localhost:3000',
  locale: () => i18n.language,
  getAuthHeader: () => \`Bearer \${token}\`,
  refreshAuth: async () => \`Bearer \${await refresh()}\`,
})

await pgbo.list('warehouse', { search: 'main' })
await pgbo.detail('warehouse', 'main')
await pgbo.create('warehouse', { name: 'X' })
await pgbo.update('warehouse', 'main', { name: 'Renamed' })
await pgbo.action<Blob>('doc', 'pdf', { id: 1 }, { responseType: 'blob' })

const meta = await pgbo.meta('warehouse')   // cached after first call
const uoms = await pgbo.valueHelp('product', 'uom')   // unwrapped — already an array
\`\`\`

## What's in the box

- **\`createClient(config)\`** — \`meta\`, \`list\`, \`detail\`, \`create\`, \`update\`, \`delete\`, \`action\`, \`valueHelp\`, \`valueHelpPaged\`, \`view\`, \`viewPaged\`, \`viewMeta\`, \`invalidateMeta\`
- **URL builders** — \`urlForProjection\` / \`urlForDetail\` / \`urlForAction\` / \`urlForValueHelp\` / \`urlForMeta\` / \`urlForView\` / \`urlForViewMeta\` + \`buildQueryString\` (with pgbo's \`filter.<col>=value\` convention)
- **Re-exported types** from \`@pgbo/core\` (\`FieldMeta\`, \`BOMeta\`, \`ValueHelpRef\`, \`PaginatedResult\`, …) so frontends use a single import path — no transitive \`pg\` dependency
- **\`PublicBoMeta\`** / \`PublicFieldMeta\` — typed response shape after \`@pgbo/fastify\`'s \`/meta\` transform (labelKey populated, valueHelp/filterable endpoints absolute)
- **\`PgboClientError\`** — thrown on non-2xx with \`status\`, \`url\`, parsed \`body\`
- **401 retry** once via configurable \`refreshAuth\` callback
- **Per-projection metadata cache** with \`invalidateMeta(name?)\` to bust

## Pagination unwrap

| Method | Returns |
|---|---|
| \`list()\` | \`PaginatedResult<T>\` (UIs need \`total\`) |
| \`detail()\` | \`T\` |
| \`valueHelp()\` | \`T[]\` (unwrapped — dropdowns rarely need totals) |
| \`valueHelpPaged()\` | \`PaginatedResult<T>\` |
| \`view()\` | \`T[]\` |
| \`viewPaged()\` | \`PaginatedResult<T>\` |

## Out of scope (separate packages on top)

- Framework hooks (React / Vue / Svelte)
- UI components
- Code-generated types per BO

## Companion change in @pgbo/core

\`metadata/index.ts\` re-exports \`AssociationMeta\`, \`CompositionMeta\`, \`ValueHelpMeta\`, \`FieldKind\`, \`FilterOption\` so \`@pgbo/client\` can re-export them cleanly.

## CI / publishing

\`publish.yml\` extended to dry-run \`@pgbo/client\` alongside \`@pgbo/core\` and \`@pgbo/fastify\`. Trusted Publisher entry on npm needs to be added before the first real release.

## Test plan

- [x] 34 unit tests across \`urls.test.ts\` (URL builders + querystring serialisation) and \`client.test.ts\` (request basics, meta cache, 401 retry, locale, value helps, view routes, action JSON + blob, custom headers)
- [x] All 511 tests pass (399 core + 78 fastify + 34 client)
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run docs:build\` clean — new \`/client\` page registered in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)