### PR TITLE
docs: add CHANGELOG.md entries for the @metadataui rebrand release

### DIFF
--- a/packages/metadataui-client/CHANGELOG.md
+++ b/packages/metadataui-client/CHANGELOG.md
@@ -1,0 +1,47 @@
+# @metadataui/client
+
+## 1.0.0
+
+### Major Changes
+
+- 49c44b6: Initial release. Framework-agnostic HTTP client for the [metadata-driven UI contract](https://www.npmjs.com/package/@metadataui/spec) — drop-in replacement for `@pgbo/client` (closes #52).
+
+  ### What's in the box
+
+  - `createClient(config)` — `meta`, `list`, `detail`, `create`, `update`, `delete`, `action`, `valueHelp`, `valueHelpPaged`, `view`, `viewPaged`, `viewMeta`, `invalidateMeta`
+  - URL builders re-exported from [`@metadataui/spec`](https://www.npmjs.com/package/@metadataui/spec) (`urlForProjection`, `urlForDetail`, `urlForAction`, `urlForValueHelp`, `urlForMeta`, `urlForView`, `urlForViewMeta`, `buildQueryString`)
+  - `MetadataUiClientError` — thrown on non-2xx with `status`, `url`, parsed `body`
+  - Per-projection metadata cache with `invalidateMeta(name?)` to bust
+  - 401 retry once via configurable `refreshAuth` callback
+  - Pluggable `getAuthHeader`, locale, custom headers
+  - All wire-protocol types re-exported from `@metadataui/spec` so apps use a single import path
+
+  ### Migration from `@pgbo/client`
+
+  ```diff
+  - import { createClient, PgboClientError } from '@pgbo/client'
+  + import { createClient, MetadataUiClientError } from '@metadataui/client'
+  ```
+
+  Runtime API is identical. The only differences from `@pgbo/client@0.2.0`:
+
+  - Imports types from `@metadataui/spec` instead of `@pgbo/core/metadata` — frontend installs no `pg`, no `@types/pg`, no migration engine.
+  - Renamed `PgboClientError` → `MetadataUiClientError`.
+  - No pgbo branding in error messages or comments.
+
+  ### Why a separate package
+
+  - The contract is independent of pgbo. Other backends (Spring, Go, hand-rolled REST) can serve it; this client works against any of them.
+  - Frontend bundles never need a transitive `@pgbo/core` dependency (which pulls `pg`).
+  - Adoption is per-environment: backends use `@pgbo/core` + `@pgbo/fastify`; frontends use `@metadataui/client`.
+
+  ### Pagination unwrap
+
+  | Method | Returns |
+  |---|---|
+  | `list()` | `PaginatedResult<T>` (UIs need `total`) |
+  | `detail()` | `T` |
+  | `valueHelp()` | `T[]` (unwrapped — dropdowns rarely need totals) |
+  | `valueHelpPaged()` | `PaginatedResult<T>` |
+  | `view()` | `T[]` |
+  | `viewPaged()` | `PaginatedResult<T>` |

--- a/packages/metadataui-spec/CHANGELOG.md
+++ b/packages/metadataui-spec/CHANGELOG.md
@@ -1,0 +1,50 @@
+# @metadataui/spec
+
+## 1.0.0
+
+### Major Changes
+
+- 49c44b6: Initial release. The metadata-driven UI contract — pure types, URL builders, and the conventions any HTTP server can implement to be auto-rendered by a metadata-driven frontend.
+
+  Extracted from `@pgbo/core/metadata`, `@pgbo/core/query`, and `@pgbo/fastify` to live under a vendor-neutral namespace (closes #52).
+
+  ### What's in the contract
+
+  - **Wire-protocol types**: `BOMeta`, `FieldMeta`, `ViewMeta`, `FilterMeta`, `ValueHelpRef`, `ValueHelpMeta`, `CompositionMeta`, `AssociationMeta`, `FieldKind`, `FilterOption`
+  - **Public response shapes** (post-transform on the server): `PublicBoMeta`, `PublicFieldMeta`, `PublicValueHelpRef`, `PublicFilterMeta`
+  - **List query contract**: `ListParams`, `PaginatedResult`
+  - **Custom action returns**: `FileResponse` (typed as `Uint8Array` so it's platform-neutral; Node `Buffer` is structurally compatible)
+  - **Translation enrichment**: `TranslationConfig`, `EnrichConfig`
+
+  ### URL convention (single source of truth)
+
+  ```
+  GET    /bo/{name}                       list
+  GET    /bo/{name}/{paramValue}          detail
+  POST   /bo/{name}                       create
+  PUT    /bo/{name}/{paramValue}          update
+  DELETE /bo/{name}/{paramValue}          delete
+  GET    /meta/{name}                     metadata
+  GET    /bo/{name}/valueHelp/{vh}        value help
+  POST   /bo/{name}/{action}              custom action
+  GET    /view/{name}                     read-only view
+  GET    /view/{name}/meta                view metadata
+  ```
+
+  Each pattern has a builder helper (`urlForProjection`, `urlForDetail`, `urlForAction`, `urlForValueHelp`, `urlForMeta`, `urlForView`, `urlForViewMeta`) plus `buildQueryString` for the list query convention (`page`, `limit`, `search`, `sort`, `order`, `locale`, `filter.<col>`, `fields`).
+
+  ### Status code semantics
+
+  | Status | Meaning |
+  |---|---|
+  | `200` / `201` / `204` | Success. Create returns 201, null/undefined returns 204, others 200. |
+  | `401` | Auth required. Clients should call `refreshAuth` once and retry. |
+  | `403` | Forbidden. E.g. tenant trying to write a global record. |
+  | `404` | Not found, or filtered out by the projection's WHERE clause. |
+
+  ### Implementations
+
+  - **Server**: [`@pgbo/fastify`](https://www.npmjs.com/package/@pgbo/fastify) — Fastify route factory backed by [`@pgbo/core`](https://www.npmjs.com/package/@pgbo/core).
+  - **Client**: [`@metadataui/client`](https://www.npmjs.com/package/@metadataui/client) — framework-agnostic HTTP client.
+
+  Other backends are valid implementations as long as they conform to this contract.

--- a/packages/pgbo-client/CHANGELOG.md
+++ b/packages/pgbo-client/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @pgbo/client
 
+## 0.3.0
+
+### Minor Changes — DEPRECATED
+
+- 49c44b6: **`@pgbo/client` is renamed to `@metadataui/client`** (closes #52). This release is a deprecation shim: it re-exports everything from `@metadataui/client` and aliases `PgboClientError → MetadataUiClientError`. A one-time `console.warn` fires at module load. **The next major will remove this package.**
+
+  ### Migration (one find-and-replace)
+
+  ```diff
+  - import { createClient, PgboClientError } from '@pgbo/client'
+  + import { createClient, MetadataUiClientError } from '@metadataui/client'
+  ```
+
+  The runtime API is identical. After upgrading, drop `@pgbo/client` from `package.json` and add `@metadataui/client`.
+
+  ### Why the rename
+
+  The metadata-driven UI contract — URL conventions, response shapes, status-code semantics — is independent of pgbo. It now lives under a vendor-neutral namespace so other backends (Spring, Go, hand-rolled REST) can implement it without taking pgbo as a dependency.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/pgbo-fastify/CHANGELOG.md
+++ b/packages/pgbo-fastify/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @pgbo/fastify
 
+## 3.1.0
+
+### Minor Changes
+
+- 49c44b6: Rebrand `@pgbo/client` → `@metadataui/*` (closes #52). The metadata-driven UI contract is independent of pgbo, so it now lives under a vendor-neutral namespace.
+
+  ### What changed in `@pgbo/fastify`
+
+  - `FileResponse` re-exports from `@metadataui/spec` — same shape, single source of truth across server (pgbo-fastify) and client (metadataui-client).
+  - Adds `@metadataui/spec` as a dependency.
+  - `transformProjectionMeta` continues to return the `PublicBoMeta` shape, now imported from spec.
+
+  No source-level migration required. Existing `import { FileResponse } from '@pgbo/fastify'` keeps working.
+
+  ### Companion releases
+
+  - **`@metadataui/spec@1.0.0`** — the contract. Pure types + URL builders + status-code semantics. Zero runtime deps.
+  - **`@metadataui/client@1.0.0`** — drop-in replacement for `@pgbo/client`.
+  - **`@pgbo/core@1.1.0`** — re-exports metadata types from `@metadataui/spec`.
+  - **`@pgbo/client@0.3.0`** — deprecated re-export shim.
+
+### Patch Changes
+
+- Updated dependencies [49c44b6]
+  - @pgbo/core@1.1.0
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/pgbo/CHANGELOG.md
+++ b/packages/pgbo/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @pgbo/core
 
+## 1.1.0
+
+### Minor Changes
+
+- 49c44b6: Rebrand `@pgbo/client` → `@metadataui/*` (closes #52). The metadata-driven UI contract — URL conventions, response shapes, status-code semantics — is independent of pgbo, so it now lives under a vendor-neutral namespace. Other backends (Spring, Go, hand-rolled REST) can implement it without taking pgbo as a dependency.
+
+  ### What changed in `@pgbo/core`
+
+  - `metadata/types.ts` re-exports the wire-protocol types (`FieldMeta`, `BOMeta`, `ViewMeta`, `FilterMeta`, `ValueHelpRef`, `ValueHelpMeta`, `CompositionMeta`, `AssociationMeta`, `EnrichConfig`) from `@metadataui/spec`.
+  - `FieldKind` and `FilterOption` re-export from `@metadataui/spec` too — kept available from `@pgbo/core/schema` and `@pgbo/core/metadata` for backward compat.
+  - `ListParams` and `PaginatedResult` in `@pgbo/core/query` re-export from `@metadataui/spec`.
+  - Adds `@metadataui/spec` as a dependency.
+
+  ### Backward compatibility
+
+  All existing import paths still resolve. Code that imports `FieldMeta` from `@pgbo/core/metadata` (or `FieldKind` from `@pgbo/core/schema`) keeps working — those names now point at `@metadataui/spec` types but the resolution is invisible to consumers.
+
+  ### Companion releases
+
+  - **`@metadataui/spec@1.0.0`** — new vendor-neutral package. Pure types + URL builders + status-code semantics.
+  - **`@metadataui/client@1.0.0`** — new package. Drop-in replacement for `@pgbo/client`.
+  - **`@pgbo/fastify@3.1.0`** — `FileResponse` re-exports from `@metadataui/spec`.
+  - **`@pgbo/client@0.3.0`** — deprecated; re-exports `@metadataui/client`. Will be removed in the next major.
+
 ## 1.0.0
 
 ### Major Changes


### PR DESCRIPTION
## Summary

PR #53 merged before its changeset commit (\`29e09e3\`) landed, so the version-PR flow never wrote CHANGELOGs for the bumped versions. This PR backfills them manually so the next \`publish.yml\` run releases each package with proper release notes attached to the GitHub release.

## What's in here

- \`packages/pgbo/CHANGELOG.md\` — adds **1.1.0** entry (re-exports from \`@metadataui/spec\`)
- \`packages/pgbo-fastify/CHANGELOG.md\` — adds **3.1.0** entry (\`FileResponse\` re-exports from spec)
- \`packages/pgbo-client/CHANGELOG.md\` — adds **0.3.0** entry (deprecation shim, removed next major)
- \`packages/metadataui-spec/CHANGELOG.md\` — **new file**, 1.0.0 describing the contract
- \`packages/metadataui-client/CHANGELOG.md\` — **new file**, 1.0.0 describing the client + migration from \`@pgbo/client\`

## What's NOT in here

- No \`package.json\` changes — versions on main are already at the target values (1.1.0 / 3.1.0 / 0.3.0 / 1.0.0 / 1.0.0)
- No \`.changeset/*.md\` file — adding one would cause \`changeset version\` to bump again on top of the already-bumped versions

## Why backfill manually instead of using a changeset

\`changeset publish\` (run via the publish workflow) reads \`package.json\` versions and publishes whatever isn't yet on npm. It uses \`CHANGELOG.md\` as the source for GitHub release notes. So with versions correct in \`package.json\` and CHANGELOGs written by hand, the publish flow has everything it needs.

## After merge

The publish workflow can ship all five packages:
- \`@metadataui/spec@1.0.0\` (first publish — needs manual bootstrap from a logged-in shell)
- \`@metadataui/client@1.0.0\` (first publish — same)
- \`@pgbo/core@1.1.0\` (OIDC via Trusted Publisher)
- \`@pgbo/fastify@3.1.0\` (OIDC)
- \`@pgbo/client@0.3.0\` (OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)