### PR TITLE
fix(core): diff/migrate recreates views when column set drifts (closes #55)

### DIFF
--- a/.changeset/recreate-stale-views.md
+++ b/.changeset/recreate-stale-views.md
@@ -1,0 +1,27 @@
+---
+"@pgbo/core": minor
+---
+
+`diff()` now detects view column-set drift and emits `dropView` + `createView` to recreate stale views (closes #55).
+
+Before this change, adding/renaming/removing a column on a `view().columns({...})` definition produced no migration operation — the live view was never updated, and queries silently returned missing columns. The workaround was to manually `DROP VIEW … CASCADE` before every migrate.
+
+### What's new
+
+1. **`SnapshotView.columns`** — `introspect()` now captures the output column names of every view from `information_schema.columns`. Optional for backward compat with hand-built fixtures.
+
+2. **Drift detection in `diff()`** — for each managed view, the diff compares the snapshot's columns against the expected columns the view definition would emit (`expectedViewColumns`). If **any** managed view differs:
+
+   - Emits `DROP VIEW IF EXISTS <name> CASCADE` for every managed view in the snapshot.
+   - Emits `CREATE VIEW <name> AS …` for every view in the schema definitions.
+
+   `CASCADE` handles dependency ordering automatically; managed dependent views get re-created from the schema. Unmanaged views that depend on managed ones are dropped silently — either register them with the schema or recreate them out-of-band.
+
+3. **New `dropView` operation type** added to `MigrationOperation`.
+
+4. **Docs** — `docs/migration.md` updated with the view-recreate behaviour and a new "Scope: additive-only" section calling out what the diff engine deliberately doesn't detect (column drops, type changes, renames, etc.).
+
+### Backward compatibility
+
+- Existing migrations that don't touch view definitions produce identical plans — drift detection is skipped when no view has changed.
+- `SnapshotView.columns` is optional; older callers that construct snapshots by hand keep working (drift detection is skipped for views without a `columns` field).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -65,11 +65,36 @@ for (const op of plan.operations) {
 | `createTable` | New table (includes translation tables) |
 | `addColumn` | New column on existing table |
 | `createIndex` | New index on existing table |
-| `createView` | New view |
+| `dropView` | Drop a view whose column set has drifted (issue #55) — always paired with `createView` to re-create it |
+| `createView` | New view, or recreate of a view whose column set drifted |
 
 ### Dependency Ordering
 
-Operations are ordered by dependency: **domains -> enums -> tables -> indexes -> views**. Translation tables declared via `.translations()` are automatically included.
+Operations are ordered by dependency: **domains → enums → tables → indexes → views**. Translation tables declared via `.translations()` are automatically included.
+
+### View column-set drift (issue #55)
+
+Postgres has no `CREATE OR REPLACE VIEW` that allows column-list changes — only DROP + CREATE handles renaming, adding, or removing columns. The diff engine compares each managed view's expected output columns against `information_schema.columns`. If **any** managed view differs, the plan emits:
+
+1. `DROP VIEW IF EXISTS <name> CASCADE` for every managed view in the snapshot.
+2. `CREATE VIEW <name> AS …` for every view in the schema definitions.
+
+`CASCADE` handles dependency ordering automatically. The trade-off: an **unmanaged** view that depends on a managed one is dropped silently (the schema doesn't know about it). Either register every view with the schema or recreate the unmanaged one out-of-band after migration.
+
+When no managed view's column set has drifted, only newly-defined views get a `createView` — existing ones are left alone.
+
+### Scope: additive-only (with the view-recreate exception)
+
+The diff engine is **deliberately additive** for everything except views:
+
+| Detected | Not detected |
+|---|---|
+| New domain / enum / table / column / index / view | Dropped column / table / index |
+| Enum value added | Enum value removed (Postgres can't anyway) |
+| Drifted view column set → drop + recreate | Column type change, default change, constraint change |
+| | Renamed column / table / index |
+
+Destructive changes (drops, renames, type changes) are intentionally out of scope — they require human review and downtime planning that an auto-diff can't infer. For those, write a hand-rolled migration script and run it before `migrate()`.
 
 ## Migrate
 

--- a/packages/pgbo/src/migration/diff.ts
+++ b/packages/pgbo/src/migration/diff.ts
@@ -1,9 +1,11 @@
 // Schema diff algorithm — Phase 4 (Step 13)
 
 import type { DatabaseSnapshot } from './introspect.js'
-import type { TableDef, DomainDef, EnumDef, ViewDef } from '../schema/definitions.js'
+import type { TableDef, DomainDef, EnumDef, ViewDef, ColumnRef } from '../schema/definitions.js'
 import type { BusinessObjectDef } from '../bo/types.js'
 import { toSnakeCase, generateIndexName } from '../schema/table.js'
+import { isTranslatedRef } from '../schema/i18n.js'
+import { isSubqueryCountRef } from '../schema/subquery.js'
 
 export interface MigrationOperation {
   readonly type:
@@ -13,6 +15,7 @@ export interface MigrationOperation {
     | 'createTable'
     | 'addColumn'
     | 'createIndex'
+    | 'dropView'
     | 'createView'
   readonly sql: string
   readonly tableName?: string
@@ -139,17 +142,105 @@ export function diff(definitions: SchemaDefinitions, snapshot: DatabaseSnapshot)
       allViews.push(vh)
     }
   }
+  // Detect column-set drift between schema-defined views and the live database.
+  // When ANY managed view has changed columns we drop ALL managed views (CASCADE
+  // handles dependent-view ordering) and re-create them all from the definitions
+  // (issue #55). Postgres has no `CREATE OR REPLACE VIEW` that allows column-list
+  // changes — only DROP + CREATE works for renaming/adding/removing columns.
+  const liveViewNames = new Set(snapshot.views.map(v => v.name))
+  let anyStale = false
   for (const viewDef of allViews) {
+    if (!liveViewNames.has(viewDef.name)) continue
     const existing = snapshot.views.find(v => v.name === viewDef.name)
-    if (!existing) {
+    if (!existing) continue
+    // Snapshot fixtures from older callers may not populate `columns` —
+    // treat that as "skip drift detection for this view" (matches old
+    // additive-only behaviour rather than spuriously marking it stale).
+    if (!existing.columns) continue
+    const expected = expectedViewColumns(viewDef)
+    if (!columnArraysEqual(expected, existing.columns)) {
+      anyStale = true
+      break
+    }
+  }
+
+  if (anyStale) {
+    // CASCADE drops dependent views too — managed views that depend on stale ones
+    // get re-created from `allViews` below. Unmanaged views that depend on managed
+    // ones are silently dropped — register them with the schema or expect to
+    // recreate them out-of-band.
+    for (const viewDef of allViews) {
+      if (liveViewNames.has(viewDef.name)) {
+        operations.push({
+          type: 'dropView',
+          sql: `DROP VIEW IF EXISTS ${viewDef.name} CASCADE`,
+        })
+      }
+    }
+    for (const viewDef of allViews) {
       operations.push({
         type: 'createView',
         sql: viewDef.toSQL(),
       })
     }
+  } else {
+    // No drift — only create views that don't exist yet.
+    for (const viewDef of allViews) {
+      if (!liveViewNames.has(viewDef.name)) {
+        operations.push({
+          type: 'createView',
+          sql: viewDef.toSQL(),
+        })
+      }
+    }
   }
 
   return { operations }
+}
+
+/** Strict equality on ordered string arrays — used for view column-set comparison. */
+function columnArraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/** Compute the output column names a view would emit, mirroring the logic in
+ * `view.ts`'s `toSQL()`. Used to detect column-set drift against the live schema. */
+function expectedViewColumns(viewDef: ViewDef): string[] {
+  const cols: string[] = []
+  const selected = viewDef.selectedColumns
+
+  if (selected) {
+    for (const [outputName, entry] of Object.entries(selected)) {
+      if (isTranslatedRef(entry)) {
+        // toSQL emits `<translation_table>.<ref>` with no AS — column name is `ref`.
+        cols.push(toSnakeCase(entry.ref))
+      } else if (isSubqueryCountRef(entry)) {
+        cols.push(toSnakeCase(outputName))
+      } else {
+        const colRef = entry as ColumnRef
+        // toSQL: with sourceTable → `... AS <outputName>`; without → just the ref.
+        cols.push(toSnakeCase(colRef.sourceTable ? outputName : colRef.ref))
+      }
+    }
+  } else {
+    // No `.columns()` → all source-table columns.
+    for (const colName of Object.keys(viewDef.source.columns)) {
+      cols.push(toSnakeCase(colName))
+    }
+  }
+
+  // `.translatedJoin()` appends each field as a top-level column.
+  if (viewDef.translatedJoinSpec) {
+    for (const field of viewDef.translatedJoinSpec.fields) {
+      cols.push(toSnakeCase(field))
+    }
+  }
+
+  return cols
 }
 
 /** Walk BOs, collect unique value-help views by name. Multiple BOs can share a value

--- a/packages/pgbo/src/migration/introspect.ts
+++ b/packages/pgbo/src/migration/introspect.ts
@@ -54,6 +54,16 @@ export interface SnapshotEnum {
 export interface SnapshotView {
   readonly name: string
   readonly definition: string
+  /**
+   * Output column names of the view (snake_case as Postgres stores them).
+   * Used by `diff()` to detect column-set drift between the schema definition
+   * and the live view, so stale views can be DROP/CREATE-recycled (issue #55).
+   *
+   * Optional for backward compatibility with callers that construct snapshots
+   * by hand (e.g. older test fixtures); when absent, `diff()` skips drift
+   * detection for that view and reverts to the additive-only behaviour.
+   */
+  readonly columns?: readonly string[]
 }
 
 export interface DatabaseSnapshot {
@@ -84,6 +94,7 @@ type IndexRow = {
   [key: string]: unknown
 }
 type ViewRow = { table_name: string; view_definition: string; [key: string]: unknown }
+type ViewColumnRow = { table_name: string; column_name: string; ordinal_position: number; [key: string]: unknown }
 type TableNameRow = { table_name: string; [key: string]: unknown }
 
 export async function introspect(db: Queryable): Promise<DatabaseSnapshot> {
@@ -278,9 +289,25 @@ export async function introspect(db: Queryable): Promise<DatabaseSnapshot> {
      WHERE table_schema = 'public'`,
   )
 
+  const viewColumnRows = await db.query<ViewColumnRow>(
+    `SELECT c.table_name, c.column_name, c.ordinal_position
+     FROM information_schema.columns c
+     JOIN information_schema.views v
+       ON v.table_schema = c.table_schema AND v.table_name = c.table_name
+     WHERE c.table_schema = 'public'
+     ORDER BY c.table_name, c.ordinal_position`,
+  )
+  const viewColumnsByName = new Map<string, string[]>()
+  for (const r of viewColumnRows) {
+    const list = viewColumnsByName.get(r.table_name)
+    if (list) list.push(r.column_name)
+    else viewColumnsByName.set(r.table_name, [r.column_name])
+  }
+
   const views: SnapshotView[] = viewRows.map(r => ({
     name: r.table_name,
     definition: r.view_definition,
+    columns: viewColumnsByName.get(r.table_name) ?? [],
   }))
 
   return { domains, enums, tables, views }

--- a/packages/pgbo/tests/migration/execute.test.ts
+++ b/packages/pgbo/tests/migration/execute.test.ts
@@ -151,6 +151,93 @@ describe('Migration execution', () => {
     }
   })
 
+  it('recreates a view when its column set drifts from the snapshot (issue #55)', async () => {
+    const driftDb = await createTestDatabase({ connectionString, schema: [] })
+    try {
+      // Round 1 — initial schema with a 2-column view
+      const round1Table = table('thing', {
+        columns: { id: integer().notNull(), slug: text().notNull() },
+        primaryKey: ['id'],
+      })
+      const round1View = view('thing_view').from(round1Table).columns({
+        id: col('id'),
+        slug: col('slug'),
+      })
+
+      const plan1 = diff(
+        { domains: [], enums: [], tables: [round1Table], views: [round1View] },
+        await introspect(driftDb.db),
+      )
+      await migrate(driftDb.db, plan1)
+
+      const after1 = await introspect(driftDb.db)
+      expect(after1.views.find(v => v.name === 'thing_view')?.columns).toEqual(['id', 'slug'])
+
+      // Round 2 — add `name` to the table + the view. Without #55's fix the
+      // diff plan would only ALTER TABLE; the view would stay 2-columns wide.
+      const round2Table = table('thing', {
+        columns: { id: integer().notNull(), slug: text().notNull(), name: text() },
+        primaryKey: ['id'],
+      })
+      const round2View = view('thing_view').from(round2Table).columns({
+        id: col('id'),
+        slug: col('slug'),
+        name: col('name'),
+      })
+
+      const plan2 = diff(
+        { domains: [], enums: [], tables: [round2Table], views: [round2View] },
+        await introspect(driftDb.db),
+      )
+
+      const ops = plan2.operations.map(o => o.type)
+      expect(ops).toContain('addColumn')
+      expect(ops).toContain('dropView')
+      expect(ops).toContain('createView')
+
+      await migrate(driftDb.db, plan2)
+
+      const after2 = await introspect(driftDb.db)
+      expect(after2.views.find(v => v.name === 'thing_view')?.columns).toEqual(['id', 'slug', 'name'])
+
+      // And the new column is queryable through the view
+      await driftDb.db.query("INSERT INTO thing (id, slug, name) VALUES (1, 'a', 'Alpha')")
+      const rows = await driftDb.db.query<{ id: number; slug: string; name: string }>(
+        'SELECT id, slug, name FROM thing_view ORDER BY id',
+      )
+      expect(rows).toEqual([{ id: 1, slug: 'a', name: 'Alpha' }])
+    } finally {
+      await driftDb.dispose()
+    }
+  })
+
+  it('does NOT recreate views when nothing changed', async () => {
+    const stableDb = await createTestDatabase({ connectionString, schema: [] })
+    try {
+      const t = table('thing', {
+        columns: { id: integer().notNull(), slug: text().notNull() },
+        primaryKey: ['id'],
+      })
+      const v = view('thing_view').from(t).columns({ id: col('id'), slug: col('slug') })
+
+      const plan1 = diff(
+        { domains: [], enums: [], tables: [t], views: [v] },
+        await introspect(stableDb.db),
+      )
+      await migrate(stableDb.db, plan1)
+
+      const plan2 = diff(
+        { domains: [], enums: [], tables: [t], views: [v] },
+        await introspect(stableDb.db),
+      )
+      // Same definition → no DROP/CREATE for the view
+      expect(plan2.operations.map(o => o.type)).not.toContain('dropView')
+      expect(plan2.operations.map(o => o.type)).not.toContain('createView')
+    } finally {
+      await stableDb.dispose()
+    }
+  })
+
   it('records migration in _pgbo_migrations table', async () => {
     const rows = await testDb.db.query<{ id: number; applied_at: Date; [key: string]: unknown }>(
       'SELECT id, applied_at FROM _pgbo_migrations ORDER BY id',


### PR DESCRIPTION
## Summary

Adding/renaming/removing a column on a \`view().columns({...})\` definition produced no migration operation — the live view stayed stale and queries silently returned missing columns. The workaround was to manually \`DROP VIEW … CASCADE\` before every migrate.

This PR teaches \`diff()\` to detect column-set drift and emit \`dropView\` + \`createView\` for every managed view when **any** has changed.

## How it works

1. **\`introspect()\`** now captures view output columns from \`information_schema.columns\` into a new \`SnapshotView.columns\` field (optional, for backward compat with hand-built fixtures).

2. **\`diff()\`** computes the expected output columns each \`ViewDef\` would emit (by mirroring \`view.toSQL\`'s logic) and compares against the snapshot. When **any** managed view drifts:
   - \`DROP VIEW IF EXISTS <name> CASCADE\` for every managed view in the snapshot (\`CASCADE\` handles dependency ordering).
   - \`CREATE VIEW <name>\` for every view in the schema definitions.
   When nothing has drifted, behaviour is unchanged — only missing views get created.

3. **New \`dropView\` op type** added to \`MigrationOperation\`.

## Trade-offs

- An **unmanaged** view that depends on a managed one gets dropped silently when CASCADE fires. Register it with the schema, or recreate it out-of-band after migration. Documented in \`docs/migration.md\`.
- The diff is still **additive-only** for column drops, type changes, default changes, and renames. The new docs section calls these out explicitly so users budget for them.

## Test plan

- [x] New end-to-end test (\`execute.test.ts\`): define view with 2 cols → migrate → add 3rd col + ALTER TABLE → re-migrate → verify \`dropView\` + \`createView\` appear in the plan and the new column is queryable through the view.
- [x] Stable-state test: no changes produces no view ops (no spurious recreates).
- [x] All 519 tests pass (21 spec + 13 metadataui-client + **401 core** + 4 deprecation-shim + 80 fastify) — net +2 from this PR.
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run docs:build\` clean — \`migration.md\` updated with the view-recreate behaviour and a new "Scope: additive-only" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)