### PR TITLE
docs: add @metadataui/spec + @metadataui/client to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,34 @@ A TypeScript framework for PostgreSQL that enforces a clean three-layer architec
 
 ## Packages
 
+### Server
+
 | Package | Description |
 |---|---|
 | [`@pgbo/core`](packages/pgbo) | Schema DSL, query builder, migrations, BO framework, metadata, validation, seeding, testing |
 | [`@pgbo/fastify`](packages/pgbo-fastify) | Fastify route factory for CRUD, metadata, value helps, pagination |
 
+### Metadata-driven UI contract
+
+| Package | Description |
+|---|---|
+| [`@metadataui/spec`](packages/metadataui-spec) | The contract: types + URL builders + status-code semantics. Pure, zero runtime deps. Any HTTP server can implement it; any frontend can consume it. |
+| [`@metadataui/client`](packages/metadataui-client) | Framework-agnostic HTTP client for the contract — URL composition, typed fetch, metadata cache, 401 retry. |
+
+`@pgbo/core` + `@pgbo/fastify` are one implementation of the contract — the easiest one — but other backends (Spring, Go, hand-rolled REST) become valid implementations as long as they conform to `@metadataui/spec`.
+
 ## Install
 
 ```bash
+# Server side
 npm install @pgbo/core
-npm install @pgbo/fastify   # if using Fastify
+npm install @pgbo/fastify    # if using Fastify
+
+# Frontend
+npm install @metadataui/client
 ```
+
+> `@pgbo/client` is **deprecated** and renamed to `@metadataui/client`. Migrate with one find-and-replace; `@pgbo/client@0.3.0` is a thin re-export shim that prints a deprecation warning.
 
 ## Key concepts
 
@@ -43,6 +60,9 @@ Browse the full docs at **<https://tim-riep.github.io/pgbo/>**:
 - [Query Builder](https://tim-riep.github.io/pgbo/query) — SELECT/INSERT/UPDATE/DELETE, caching, transactions
 - [Business Objects](https://tim-riep.github.io/pgbo/bo) — `defineBO`, actions, compositions, associations
 - [Migration Engine](https://tim-riep.github.io/pgbo/migration) — introspect, diff, migrate
+- [`@pgbo/fastify`](https://tim-riep.github.io/pgbo/fastify) — route factory, OpenAPI, value helps, session params
+- [`@metadataui/spec`](https://tim-riep.github.io/pgbo/metadataui-spec) — the contract
+- [`@metadataui/client`](https://tim-riep.github.io/pgbo/metadataui-client) — HTTP client
 
 Or read them directly in the repo under [`docs/`](docs/index.md).
 


### PR DESCRIPTION
## Summary

The README only listed \`@pgbo/core\` and \`@pgbo/fastify\`. Adds the two new \`@metadataui/*\` packages and clarifies the relationship between them and pgbo.

## Changes

- **Packages table** split into "Server" (\`@pgbo/core\`, \`@pgbo/fastify\`) and "Metadata-driven UI contract" (\`@metadataui/spec\`, \`@metadataui/client\`).
- Notes that \`@pgbo/core\` + \`@pgbo/fastify\` are one implementation of the contract — other backends (Spring, Go, hand-rolled REST) become valid implementations as long as they conform.
- **Install** section gains frontend instructions (\`npm install @metadataui/client\`).
- Callout that \`@pgbo/client\` is deprecated and renamed; the 0.3.0 release is a thin re-export shim that prints a deprecation warning.
- Documentation links list now includes \`@pgbo/fastify\`, \`@metadataui/spec\`, and \`@metadataui/client\` doc pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)