### PR TITLE
feat(core): system-managed timestamps via .systemCreatedAt / .systemUpdatedAt (closes #61)

### DIFF
--- a/.changeset/system-timestamps.md
+++ b/.changeset/system-timestamps.md
@@ -1,0 +1,44 @@
+---
+"@pgbo/core": minor
+"@metadataui/spec": minor
+---
+
+System-managed timestamps (closes #61).
+
+A near-universal pattern: every entity has `createdAt` / `updatedAt`. Until now, declaring them as plain `timestamp().withTimeZone().notNull().defaultNow()` columns left them looking like any other writable field — `/meta/{name}` returned them with `inForm: true`, auto-generated forms rendered them as datetime inputs, and a naive client submission silently overwrote the timestamps. `updatedAt` also never advanced because the SQL DEFAULT only fires on INSERT.
+
+### New API
+
+`@pgbo/core/schema`:
+
+- **`.systemCreatedAt()`** / **`.systemUpdatedAt()`** column-builder methods. Set `NOT NULL DEFAULT now()` and tag the column as system-managed.
+- **`systemTimestamps()`** helper — returns a `{ createdAt, updatedAt }` pair ready to spread into a table's `columns`.
+
+```ts
+import { table, text, systemTimestamps } from '@pgbo/core/schema'
+
+const apps = table('app', {
+  columns: {
+    slug: text().notNull(),
+    name: text().notNull(),
+    ...systemTimestamps(),
+  },
+  primaryKey: ['slug'],
+})
+```
+
+`@metadataui/spec`:
+
+- **`FieldMeta.systemManaged?: 'createdAt' | 'updatedAt'`** + same on `PublicFieldMeta`. Frontends use it to render audit timestamps differently from user-editable fields.
+
+### Behaviour wired in
+
+- **DDL**: `timestamptz NOT NULL DEFAULT now()`
+- **Metadata**: `inForm: false, immutable: true, required: false` regardless of any other annotations on the column ref
+- **BO `create`**: client-supplied values for system-managed columns are stripped before the `INSERT`; the table DEFAULT fills them
+- **BO `update`**: client-supplied values are stripped, then every `updatedAt` column is auto-stamped with `now()` so the timestamp actually advances
+- **`@pgbo/fastify`**: relies on the BO's strip — no separate work needed; payloads passing through `POST` / `PUT` to `bo.create` / `bo.update` get cleaned before SQL
+
+### Backward compatibility
+
+Purely additive — existing schemas that declare `createdAt`/`updatedAt` as regular columns keep working unchanged. The new behaviour only activates when you opt in via `.systemCreatedAt()` / `.systemUpdatedAt()` / `systemTimestamps()`.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -67,6 +67,34 @@ integer().positive()                // CHECK (col > 0)
 // Type-specific
 numeric().precision(10, 2)          // numeric(10,2)
 timestamp().withTimeZone()          // timestamptz
+
+// System-managed timestamps (issue #61)
+timestamp().withTimeZone().systemCreatedAt()  // NOT NULL DEFAULT now() + form-hidden + immutable
+timestamp().withTimeZone().systemUpdatedAt()  // same + auto-stamps now() on every BO update
+```
+
+### System-managed timestamps
+
+`createdAt` / `updatedAt` are a near-universal pattern. Marking them with the dedicated builders gives you four things at once:
+
+- **DDL**: `timestamptz NOT NULL DEFAULT now()`
+- **Metadata**: `inForm: false, immutable: true, required: false` so auto-generated forms skip them and `meta.fields[i].systemManaged` carries the marker for frontends that want to render an audit timestamp explicitly
+- **BO writes**: `create` ignores any client-supplied value (table DEFAULT fills it); `update` strips client-supplied values **and** auto-stamps every `updatedAt` column with `now()` so the timestamp actually advances on every write
+- **API**: `POST` / `PUT` payloads can't overwrite these fields even if a client sends them
+
+Use the `systemTimestamps()` shorthand to add both columns at once:
+
+```typescript
+import { table, text, systemTimestamps } from '@pgbo/core/schema'
+
+const apps = table('app', {
+  columns: {
+    slug: text().notNull(),
+    name: text().notNull(),
+    ...systemTimestamps(),
+  },
+  primaryKey: ['slug'],
+})
 ```
 
 ## Tables

--- a/packages/metadataui-spec/src/types.ts
+++ b/packages/metadataui-spec/src/types.ts
@@ -50,6 +50,14 @@ export interface FieldMeta {
   readonly inForm: boolean
   readonly required: boolean
   readonly quick: boolean
+  /**
+   * System-managed timestamp marker (issue #61). Set when the column was
+   * declared with `.systemCreatedAt()` / `.systemUpdatedAt()` (or via the
+   * `systemTimestamps()` helper). Always paired with `inForm: false,
+   * immutable: true`. Servers should auto-stamp `updatedAt` on writes
+   * and strip these fields from incoming payloads.
+   */
+  readonly systemManaged?: 'createdAt' | 'updatedAt'
 }
 
 // --- Aggregate metadata ---
@@ -119,6 +127,8 @@ export interface PublicFieldMeta {
   readonly inForm: boolean
   readonly required: boolean
   readonly quick: boolean
+  /** System-managed timestamp marker (issue #61). See `FieldMeta.systemManaged`. */
+  readonly systemManaged?: 'createdAt' | 'updatedAt'
 }
 
 /** The shape returned by `GET /meta/{name}` — what frontends consume. */

--- a/packages/pgbo/src/bo/actions.ts
+++ b/packages/pgbo/src/bo/actions.ts
@@ -1,7 +1,7 @@
 // Standard action handlers — Phase 7 (Step 17)
 
 import type { Database } from '../query/client.js'
-import type { TableDef } from '../schema/definitions.js'
+import type { TableDef, AnyColumnBuilder } from '../schema/definitions.js'
 import type { BusinessObjectDef, ActionContext } from './types.js'
 
 function getTable(bo: BusinessObjectDef): TableDef {
@@ -9,6 +9,30 @@ function getTable(bo: BusinessObjectDef): TableDef {
   if ('columns' in root && 'primaryKey' in root) return root
   if ('source' in root) return root.source
   throw new Error(`Cannot resolve table from BO root`)
+}
+
+/** Walk the root table's columns and split out which are system-managed (issue #61). */
+function systemManagedColumns(table: TableDef): { createdAt: string[]; updatedAt: string[] } {
+  const result = { createdAt: [] as string[], updatedAt: [] as string[] }
+  for (const [camelName, builder] of Object.entries(table.columns)) {
+    const sm = (builder as AnyColumnBuilder)._def.systemManaged
+    if (sm === 'createdAt') result.createdAt.push(camelName)
+    else if (sm === 'updatedAt') result.updatedAt.push(camelName)
+  }
+  return result
+}
+
+/** Drop client-supplied values for system-managed columns — they're owned by the framework. */
+function stripSystemManagedKeys(
+  data: Record<string, unknown>,
+  systemCols: { createdAt: string[]; updatedAt: string[] },
+): Record<string, unknown> {
+  const banned = new Set([...systemCols.createdAt, ...systemCols.updatedAt])
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(data)) {
+    if (!banned.has(k)) out[k] = v
+  }
+  return out
 }
 
 export async function executeAction(
@@ -45,18 +69,22 @@ export async function executeAction(
 
   // Use internal _table API — BO framework writes directly to tables
   const table = getTable(bo)
+  const systemCols = systemManagedColumns(table)
   let result: unknown
 
   switch (actionName) {
     case 'create': {
-      // Strip composition keys from parent data
+      // Strip composition keys + system-managed columns from parent data.
+      // System-managed columns get their value from the table's DEFAULT now()
+      // — clients can't override them (issue #61).
       const compositionKeys = new Set(Object.keys(bo.compositions))
       const parentData: Record<string, unknown> = {}
       for (const [k, v] of Object.entries(data)) {
         if (!compositionKeys.has(k)) parentData[k] = v
       }
+      const cleaned = stripSystemManagedKeys(parentData, systemCols)
 
-      const rows = await db._table.into(table).values(parentData).returning('*').execute()
+      const rows = await db._table.into(table).values(cleaned).returning('*').execute()
       result = rows[0]
 
       // Handle compositions on create. Link-table compositions (M2M) are
@@ -81,9 +109,16 @@ export async function executeAction(
       break
     }
     case 'update': {
-      const { [bo.paramField]: paramValue, ...updateData } = data
+      const { [bo.paramField]: paramValue, ...rawUpdateData } = data
+      // Strip any client-supplied system-managed values, then auto-stamp every
+      // `updatedAt` column with `now()` so the timestamp actually advances on
+      // each write (issue #61).
+      const cleaned = stripSystemManagedKeys(rawUpdateData, systemCols)
+      const stamp = new Date()
+      for (const col of systemCols.updatedAt) cleaned[col] = stamp
+
       const rows = await db._table.update(table)
-        .set(updateData)
+        .set(cleaned)
         .where({ [bo.paramField]: paramValue })
         .returning('*')
         .execute()

--- a/packages/pgbo/src/bo/actions.ts
+++ b/packages/pgbo/src/bo/actions.ts
@@ -1,7 +1,7 @@
 // Standard action handlers — Phase 7 (Step 17)
 
 import type { Database } from '../query/client.js'
-import type { TableDef, AnyColumnBuilder } from '../schema/definitions.js'
+import type { TableDef } from '../schema/definitions.js'
 import type { BusinessObjectDef, ActionContext } from './types.js'
 
 function getTable(bo: BusinessObjectDef): TableDef {
@@ -15,7 +15,7 @@ function getTable(bo: BusinessObjectDef): TableDef {
 function systemManagedColumns(table: TableDef): { createdAt: string[]; updatedAt: string[] } {
   const result = { createdAt: [] as string[], updatedAt: [] as string[] }
   for (const [camelName, builder] of Object.entries(table.columns)) {
-    const sm = (builder as AnyColumnBuilder)._def.systemManaged
+    const sm = builder._def.systemManaged
     if (sm === 'createdAt') result.createdAt.push(camelName)
     else if (sm === 'updatedAt') result.updatedAt.push(camelName)
   }

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -92,6 +92,7 @@ function buildFieldMeta(
   annotations: ColumnRef['annotations'],
   pgType: string,
   isTranslated: boolean,
+  systemManaged?: 'createdAt' | 'updatedAt',
 ): FieldMeta {
   const kind: FieldKind = isTranslated
     ? 'translation'
@@ -109,19 +110,24 @@ function buildFieldMeta(
     ? { name: vh.name, keyField: vh.vhAnnotation.key, displayField: vh.vhAnnotation.display }
     : undefined
 
+  // System-managed timestamps (issue #61) are always immutable + form-hidden,
+  // regardless of explicit annotations on the column ref.
+  const isSystemManaged = systemManaged !== undefined
+
   return {
     key,
     kind,
     label: annotations.label,
     hidden: annotations.hidden ?? false,
-    immutable: annotations.immutable ?? false,
+    immutable: isSystemManaged ? true : (annotations.immutable ?? false),
     searchable: annotations.searchable ?? false,
     filterable,
     valueHelp,
     inList: annotations.inList ?? true,
-    inForm: annotations.inForm ?? true,
-    required: annotations.required ?? false,
+    inForm: isSystemManaged ? false : (annotations.inForm ?? true),
+    required: isSystemManaged ? false : (annotations.required ?? false),
     quick: annotations.quick ?? false,
+    ...(systemManaged && { systemManaged }),
   }
 }
 
@@ -142,13 +148,15 @@ export function viewMeta(source: ViewDef | TableDef): ViewMeta {
         const resolvedTable = colRef.sourceTable ?? sourceTable
         const colBuilder = resolvedTable.columns[colRef.ref] as AnyColumnBuilder | undefined
         const pgType = colBuilder?._def.pgType ?? 'text'
-        fields.push(buildFieldMeta(key, colRef.annotations, pgType, false))
+        const systemManaged = colBuilder?._def.systemManaged
+        fields.push(buildFieldMeta(key, colRef.annotations, pgType, false, systemManaged))
       }
     }
   } else {
     for (const [camelName, colBuilder] of Object.entries(sourceTable.columns)) {
       const pgType = (colBuilder)._def.pgType
-      fields.push(buildFieldMeta(camelName, {}, pgType, false))
+      const systemManaged = (colBuilder)._def.systemManaged
+      fields.push(buildFieldMeta(camelName, {}, pgType, false, systemManaged))
     }
   }
 

--- a/packages/pgbo/src/schema/definitions.ts
+++ b/packages/pgbo/src/schema/definitions.ts
@@ -14,6 +14,13 @@ export interface ColumnDef {
   readonly precision: number | undefined
   readonly scale: number | undefined
   readonly hasTimeZone: boolean
+  /**
+   * System-managed timestamp marker (issue #61). Set by `.systemCreatedAt()` /
+   * `.systemUpdatedAt()`. Surfaces through metadata as `inForm: false,
+   * immutable: true` so auto-generated forms skip them; BO update operations
+   * auto-stamp `updatedAt` columns on every write so `now()` actually advances.
+   */
+  readonly systemManaged?: 'createdAt' | 'updatedAt'
 }
 
 export interface ColumnBuilder<
@@ -49,6 +56,12 @@ export interface ColumnBuilder<
   // Type-specific
   precision(p: number, s?: number): ColumnBuilder<TsType, Nullable, HasDefault>
   withTimeZone(): ColumnBuilder<TsType, Nullable, HasDefault>
+
+  // System-managed timestamps (issue #61)
+  /** Mark as `createdAt`: NOT NULL DEFAULT now(). Hidden from forms, immutable. */
+  systemCreatedAt(): ColumnBuilder<TsType, false, true>
+  /** Mark as `updatedAt`: NOT NULL DEFAULT now(); BO updates auto-stamp `now()`. Hidden from forms, immutable. */
+  systemUpdatedAt(): ColumnBuilder<TsType, false, true>
 
   // DDL
   toSQL(columnName: string): string

--- a/packages/pgbo/src/schema/index.ts
+++ b/packages/pgbo/src/schema/index.ts
@@ -17,6 +17,9 @@ export {
   daterange, int4range, numrange, tsrange, tstzrange,
 } from './types.js'
 
+// System-managed timestamps shorthand (issue #61)
+export { systemTimestamps } from './system-timestamps.js'
+
 // Type inference utilities
 export type { InferRow, InferInsert, InferUpdate, InferColumnType, InferViewRow } from './infer.js'
 export type {

--- a/packages/pgbo/src/schema/system-timestamps.ts
+++ b/packages/pgbo/src/schema/system-timestamps.ts
@@ -1,0 +1,36 @@
+// System-managed timestamps shorthand (issue #61).
+//
+// Spread into a table's `columns` to add a conventional `createdAt` /
+// `updatedAt` pair without re-declaring the same five chained calls per table.
+
+import type { ColumnBuilder } from './definitions.js'
+import { timestamp } from './types.js'
+
+/**
+ * Returns `{ createdAt, updatedAt }` columns with system-managed semantics:
+ *
+ * - DDL: `timestamptz NOT NULL DEFAULT now()`
+ * - Metadata: `inForm: false, immutable: true` — auto-generated forms skip them
+ * - BO update: `updatedAt` auto-stamps `now()` on every write
+ * - `@pgbo/fastify`: stripped from incoming `POST` / `PUT` payloads
+ *
+ * ```ts
+ * const apps = table('app', {
+ *   columns: {
+ *     slug: text().notNull(),
+ *     name: text().notNull(),
+ *     ...systemTimestamps(),
+ *   },
+ *   primaryKey: ['slug'],
+ * })
+ * ```
+ */
+export function systemTimestamps(): {
+  createdAt: ColumnBuilder<Date, false, true>
+  updatedAt: ColumnBuilder<Date, false, true>
+} {
+  return {
+    createdAt: timestamp().withTimeZone().systemCreatedAt(),
+    updatedAt: timestamp().withTimeZone().systemUpdatedAt(),
+  }
+}

--- a/packages/pgbo/src/schema/types.ts
+++ b/packages/pgbo/src/schema/types.ts
@@ -102,6 +102,26 @@ class ColumnBuilderImpl<TsType, Nullable extends boolean, HasDefault extends boo
     return this.clone({ hasTimeZone: true })
   }
 
+  // System-managed timestamps (issue #61)
+
+  systemCreatedAt(): ColumnBuilderImpl<TsType, false, true> {
+    return new ColumnBuilderImpl({
+      ...this._def,
+      isNullable: false,
+      defaultValue: 'now()',
+      systemManaged: 'createdAt',
+    })
+  }
+
+  systemUpdatedAt(): ColumnBuilderImpl<TsType, false, true> {
+    return new ColumnBuilderImpl({
+      ...this._def,
+      isNullable: false,
+      defaultValue: 'now()',
+      systemManaged: 'updatedAt',
+    })
+  }
+
   // DDL
 
   toSQL(columnName: string): string {

--- a/packages/pgbo/tests/bo/system-timestamps-actions.test.ts
+++ b/packages/pgbo/tests/bo/system-timestamps-actions.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { text } from '../../src/schema/types.js'
+import { systemTimestamps } from '../../src/schema/system-timestamps.js'
+import { defineBO } from '../../src/bo/index.js'
+import { createTestDatabase, type TestDatabase } from '../../src/testing/database.js'
+
+const connectionString = process.env['PGBO_TEST_URL'] ?? 'postgresql://localhost:5432/postgres'
+
+const apps = table('app', {
+  columns: {
+    slug: text().notNull(),
+    name: text().notNull(),
+    ...systemTimestamps(),
+  },
+  primaryKey: ['slug'],
+})
+
+describe('BO writes with system-managed timestamps (issue #61)', () => {
+  let testDb: TestDatabase
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({ connectionString, schema: [apps] })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  it('create: ignores client-supplied createdAt/updatedAt; defaults set them to now()', async () => {
+    const bo = defineBO(apps, { paramField: 'slug', actions: { create: {} } })
+    const ctx = {}
+
+    // Client tries to inject ancient timestamps — they must be ignored.
+    const ancient = new Date('2000-01-01T00:00:00Z')
+    const created = await bo.create(testDb.db, ctx, {
+      slug: 'a',
+      name: 'A',
+      // @ts-expect-error — client shouldn't be allowed to send these, but the
+      // BO must defend itself even if some caller bypasses the type system.
+      createdAt: ancient,
+      updatedAt: ancient,
+    } as never) as { createdAt: Date; updatedAt: Date }
+
+    expect(created.createdAt).toBeInstanceOf(Date)
+    expect(created.updatedAt).toBeInstanceOf(Date)
+    // Both timestamps are recent, NOT the injected ancient value
+    expect(created.createdAt.getTime()).toBeGreaterThan(ancient.getTime() + 1000 * 60 * 60 * 24 * 365 * 5)
+    expect(created.updatedAt.getTime()).toBeGreaterThan(ancient.getTime() + 1000 * 60 * 60 * 24 * 365 * 5)
+  })
+
+  it('update: auto-stamps updatedAt; createdAt stays put even when client tries to change it', async () => {
+    const bo = defineBO(apps, {
+      paramField: 'slug',
+      actions: { create: {}, update: {} },
+    })
+    const ctx = {}
+
+    const initial = await bo.create(testDb.db, ctx, { slug: 'b', name: 'B' }) as { createdAt: Date; updatedAt: Date }
+    const initialCreated = initial.createdAt
+    const initialUpdated = initial.updatedAt
+
+    // Wait long enough that now() advances measurably (Postgres gives us ms precision).
+    await new Promise(r => setTimeout(r, 50))
+
+    const updated = await bo.update(testDb.db, ctx, {
+      slug: 'b',
+      name: 'B renamed',
+      // Try to reset the timestamps — must be ignored.
+      // @ts-expect-error — same as above, client shouldn't be able to send these.
+      createdAt: new Date('2000-01-01T00:00:00Z'),
+      updatedAt: new Date('2000-01-01T00:00:00Z'),
+    } as never) as { name: string; createdAt: Date; updatedAt: Date }
+
+    expect(updated.name).toBe('B renamed')
+    // createdAt is preserved (within a few ms due to Postgres rounding)
+    expect(Math.abs(updated.createdAt.getTime() - initialCreated.getTime())).toBeLessThan(10)
+    // updatedAt actually advanced
+    expect(updated.updatedAt.getTime()).toBeGreaterThan(initialUpdated.getTime())
+  })
+
+  it('update without any other fields still bumps updatedAt', async () => {
+    const bo = defineBO(apps, {
+      paramField: 'slug',
+      actions: { create: {}, update: {} },
+    })
+    const ctx = {}
+
+    const initial = await bo.create(testDb.db, ctx, { slug: 'c', name: 'C' }) as { updatedAt: Date }
+    await new Promise(r => setTimeout(r, 50))
+
+    // Empty update payload (just the param key) — auto-stamp must still fire.
+    const updated = await bo.update(testDb.db, ctx, { slug: 'c' } as never) as { updatedAt: Date }
+    expect(updated.updatedAt.getTime()).toBeGreaterThan(initial.updatedAt.getTime())
+  })
+})

--- a/packages/pgbo/tests/schema/system-timestamps.test.ts
+++ b/packages/pgbo/tests/schema/system-timestamps.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { table } from '../../src/schema/table.js'
+import { text, timestamp } from '../../src/schema/types.js'
+import { systemTimestamps } from '../../src/schema/system-timestamps.js'
+import { viewMeta } from '../../src/metadata/index.js'
+
+describe('System-managed timestamps (issue #61)', () => {
+  describe('column builder', () => {
+    it('.systemCreatedAt() emits NOT NULL DEFAULT now() and tags the column', () => {
+      const c = timestamp().withTimeZone().systemCreatedAt()
+      expect(c._def.isNullable).toBe(false)
+      expect(c._def.defaultValue).toBe('now()')
+      expect(c._def.systemManaged).toBe('createdAt')
+    })
+
+    it('.systemUpdatedAt() does the same with the updatedAt marker', () => {
+      const c = timestamp().withTimeZone().systemUpdatedAt()
+      expect(c._def.isNullable).toBe(false)
+      expect(c._def.defaultValue).toBe('now()')
+      expect(c._def.systemManaged).toBe('updatedAt')
+    })
+
+    it('toSQL includes timestamptz NOT NULL DEFAULT now()', () => {
+      const sql = timestamp().withTimeZone().systemCreatedAt().toSQL('created_at')
+      expect(sql).toBe('created_at timestamptz NOT NULL DEFAULT now()')
+    })
+  })
+
+  describe('systemTimestamps() helper', () => {
+    it('returns a { createdAt, updatedAt } pair with the right markers', () => {
+      const cols = systemTimestamps()
+      expect(cols.createdAt._def.systemManaged).toBe('createdAt')
+      expect(cols.updatedAt._def.systemManaged).toBe('updatedAt')
+      expect(cols.createdAt._def.isNullable).toBe(false)
+      expect(cols.updatedAt._def.isNullable).toBe(false)
+    })
+
+    it('spreads cleanly into a table definition', () => {
+      const apps = table('app', {
+        columns: {
+          slug: text().notNull(),
+          name: text().notNull(),
+          ...systemTimestamps(),
+        },
+        primaryKey: ['slug'],
+      })
+      expect(Object.keys(apps.columns)).toEqual(['slug', 'name', 'createdAt', 'updatedAt'])
+      expect(apps.columns.createdAt._def.systemManaged).toBe('createdAt')
+      expect(apps.columns.updatedAt._def.systemManaged).toBe('updatedAt')
+    })
+  })
+
+  describe('metadata', () => {
+    const apps = table('app', {
+      columns: {
+        slug: text().notNull(),
+        name: text().notNull(),
+        ...systemTimestamps(),
+      },
+      primaryKey: ['slug'],
+    })
+
+    it('marks system-managed fields as inForm:false, immutable:true, required:false', () => {
+      const meta = viewMeta(apps)
+      const created = meta.fields.find(f => f.key === 'createdAt')!
+      const updated = meta.fields.find(f => f.key === 'updatedAt')!
+
+      expect(created.inForm).toBe(false)
+      expect(created.immutable).toBe(true)
+      expect(created.required).toBe(false)
+      expect(created.systemManaged).toBe('createdAt')
+
+      expect(updated.inForm).toBe(false)
+      expect(updated.immutable).toBe(true)
+      expect(updated.required).toBe(false)
+      expect(updated.systemManaged).toBe('updatedAt')
+    })
+
+    it('non-system-managed fields are unaffected', () => {
+      const meta = viewMeta(apps)
+      const slug = meta.fields.find(f => f.key === 'slug')!
+      expect(slug.inForm).toBe(true)
+      expect(slug.systemManaged).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

\`createdAt\` / \`updatedAt\` are near-universal but the framework treated them like any other writable column:

- \`/meta/{name}\` returned them with \`inForm: true\`, \`immutable: false\`
- Auto-generated forms rendered them as datetime inputs
- A naive submit overwrote the real timestamps with stale form values
- \`updatedAt\` never advanced because the SQL DEFAULT only fires on INSERT

This PR adds a first-class column-builder shortcut + a helper that gives you all the right semantics by opt-in.

## New API

\`@pgbo/core/schema\`:

\`\`\`ts
timestamp().withTimeZone().systemCreatedAt()  // form-hidden + immutable
timestamp().withTimeZone().systemUpdatedAt()  // same + auto-stamps now() on every BO update

// Or the shorthand
import { systemTimestamps } from '@pgbo/core/schema'

const apps = table('app', {
  columns: {
    slug: text().notNull(),
    name: text().notNull(),
    ...systemTimestamps(),
  },
  primaryKey: ['slug'],
})
\`\`\`

\`@metadataui/spec\`:

\`\`\`ts
interface FieldMeta {
  /* …existing fields */
  readonly systemManaged?: 'createdAt' | 'updatedAt'
}
\`\`\`

## Behaviour

- **DDL**: \`timestamptz NOT NULL DEFAULT now()\`
- **Metadata**: \`inForm: false, immutable: true, required: false\` regardless of any other annotations on the column ref. \`systemManaged\` carries the marker for frontends.
- **BO \`create\`**: client-supplied values for system-managed columns are stripped before the INSERT — the table DEFAULT fills them.
- **BO \`update\`**: client-supplied values are stripped; every \`updatedAt\` column is auto-stamped with \`now()\` (\`new Date()\` on the JS side) so the timestamp actually advances even on empty payloads.
- **\`@pgbo/fastify\`**: nothing extra — POST/PUT payloads pass through \`bo.create\`/\`bo.update\` which already strip the system-managed keys.

## Test plan

- [x] **Unit** (\`schema/system-timestamps.test.ts\`, 7 tests): builder methods set the right flags; \`toSQL\` emits \`NOT NULL DEFAULT now()\`; \`systemTimestamps()\` returns the pair; metadata marks fields as \`inForm: false, immutable: true, required: false, systemManaged: 'createdAt'/'updatedAt'\`; non-system fields are unaffected.
- [x] **Integration** (\`bo/system-timestamps-actions.test.ts\`, 3 tests against a real Postgres):
  - \`create\` with injected ancient timestamps → row gets \`now()\` from the table DEFAULT.
  - \`update\` with injected ancient timestamps → \`createdAt\` preserved, \`updatedAt\` advances.
  - \`update\` with only the param key (no body) → \`updatedAt\` still bumps.
- [x] All 529 tests pass (21 spec + 13 metadataui-client + **411 core** + 4 deprecation-shim + 80 fastify) — +10 from this PR.
- [x] \`npm run lint\` clean; \`npm run typecheck\` clean; \`npm run docs:build\` clean.

## Backward compatibility

Purely additive. Existing tables declaring \`createdAt\` / \`updatedAt\` as plain \`timestamp().notNull().defaultNow()\` columns keep their current behaviour. Opt in by switching to \`.systemCreatedAt()\` / \`.systemUpdatedAt()\` / \`systemTimestamps()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)