### PR TITLE
feat(core): discriminator-aware field visibility via .visibleWhen() (closes #62)

### DIFF
--- a/.changeset/visible-when.md
+++ b/.changeset/visible-when.md
@@ -1,0 +1,54 @@
+---
+"@pgbo/core": minor
+"@metadataui/spec": minor
+---
+
+Discriminator-aware field visibility via `.visibleWhen()` (closes #62).
+
+Polymorphic tables typically have one discriminator column (`kind`, `type`, `status`) and other columns that only apply to specific values of it. Until now, `/meta/{name}` returned every field with the same `inForm: true`, with no signal that some are conditional — every metadata-driven UI had to hard-code per-table dispatch logic.
+
+### New API
+
+`@pgbo/core/schema`:
+
+- **`col(...).visibleWhen(predicate)`** column annotation. Three predicate shapes:
+
+  | Shape | Semantics |
+  |---|---|
+  | `{ kind: 'iframe' }` | Equality |
+  | `{ kind: ['iframe', 'esm_upload'] }` | OR over the array |
+  | `{ kind: 'iframe', requiresAuth: true }` | AND across keys |
+
+  Throws on empty predicates so accidentally-empty calls fail at definition time.
+
+`@metadataui/spec`:
+
+- **`VisibleWhen`** type — `Readonly<Record<string, unknown | readonly unknown[]>>`.
+- **`FieldMeta.visibleWhen?: VisibleWhen`** + same on `PublicFieldMeta`. Frontends evaluate it against the current form state on every change to show/hide the field.
+
+### Example
+
+```ts
+const appView = view('app_view').from(apps).columns({
+  slug:      col('slug').required().immutable(),
+  kind:      col('kind').required(),                     // discriminator
+  name:      col('name').required(),
+  version:   col('version').required().visibleWhen({ kind: 'esm_upload' }),
+  bundleRef: col('bundleRef').visibleWhen({ kind: 'esm_upload' }),
+  iframeUrl: col('iframeUrl').visibleWhen({ kind: 'iframe' }),
+})
+```
+
+`/meta/app` now emits `version.visibleWhen = { kind: 'esm_upload' }`. A metadata-driven form hides the field unless `formState.kind === 'esm_upload'`.
+
+### `required` composes
+
+`.required().visibleWhen({...})` means *required when visible*. The frontend skips required validation while the field is hidden, and strips hidden fields from the submit payload so toggling the discriminator doesn't carry stale data.
+
+### Server-side enforcement (out of scope)
+
+Stripping hidden columns server-side is a v1.5 follow-up. For now the frontend is responsible — a malicious client can still submit irrelevant fields. The metadata-driven UI benefit lands first; defensive server-side stripping later.
+
+### Backward compatibility
+
+Purely additive — fields without `.visibleWhen()` keep `visibleWhen: undefined` and are always visible.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -458,15 +458,44 @@ Annotations control UI behavior in the BO framework:
 
 ```typescript
 col('slug')
-  .label('crud.slug')          // i18n key for display label
-  .searchable()                // included in full-text search
-  .filterable()                // shows filter in UI
-  .immutable()                 // can't change after creation
-  .hidden()                    // excluded from metadata
-  .inList(false)               // hidden from list view
-  .inForm(false)               // hidden from form view
-  .valueHelp(warehouseVH)      // links to dropdown source
+  .label('crud.slug')                        // i18n key for display label
+  .searchable()                              // included in full-text search
+  .filterable()                              // shows filter in UI
+  .immutable()                               // can't change after creation
+  .hidden()                                  // excluded from metadata
+  .inList(false)                             // hidden from list view
+  .inForm(false)                             // hidden from form view
+  .valueHelp(warehouseVH)                    // links to dropdown source
+  .visibleWhen({ kind: 'esm_upload' })       // hide field unless form state matches (issue #62)
 ```
+
+### Discriminator-aware visibility (`.visibleWhen()`)
+
+Polymorphic tables typically have one column that acts as a *discriminator* (`kind`, `type`, `status`) and other columns that only apply to specific values of it. `.visibleWhen()` declares the dependency so metadata-driven forms hide irrelevant fields automatically — no per-table branching in the frontend.
+
+```typescript
+const appView = view('app_view').from(apps).columns({
+  slug:      col('slug').required().immutable(),
+  kind:      col('kind').required(),                       // the discriminator
+  name:      col('name').required(),
+  icon:      col('icon'),
+  version:   col('version').visibleWhen({ kind: 'esm_upload' }),
+  bundleRef: col('bundleRef').visibleWhen({ kind: 'esm_upload' }),
+  iframeUrl: col('iframeUrl').visibleWhen({ kind: 'iframe' }),
+})
+```
+
+The predicate accepts three shapes:
+
+| Shape | Semantics |
+|---|---|
+| `{ kind: 'iframe' }` | Equality — visible when `kind === 'iframe'` |
+| `{ kind: ['iframe', 'esm_upload'] }` | OR over the array — visible when `kind` is either |
+| `{ kind: 'iframe', requiresAuth: true }` | AND across keys — both must match |
+
+`visibleWhen` flows into `meta.fields[i].visibleWhen` so metadata-driven UIs evaluate it against the current form state on every change. **`required` composes:** `.required().visibleWhen({ kind: 'iframe' })` means *required when visible* — the frontend skips required validation while the field is hidden, and strips hidden fields from the submit payload so toggling the discriminator doesn't carry stale data.
+
+> Server-side enforcement (nulling out hidden columns on submit) is intentionally out of scope here — that's a follow-up. Today the frontend is responsible for stripping hidden fields from `POST` / `PUT` bodies.
 
 ## Type Inference
 

--- a/packages/metadataui-spec/src/index.ts
+++ b/packages/metadataui-spec/src/index.ts
@@ -6,7 +6,7 @@
 
 export type {
   // Field metadata
-  FieldKind, FilterOption, FilterMeta, ValueHelpRef, FieldMeta,
+  FieldKind, FilterOption, FilterMeta, ValueHelpRef, FieldMeta, VisibleWhen,
   // Aggregate metadata
   AssociationMeta, CompositionMeta, ValueHelpMeta, ViewMeta, BOMeta,
   // Public (post-transform) shapes

--- a/packages/metadataui-spec/src/types.ts
+++ b/packages/metadataui-spec/src/types.ts
@@ -24,6 +24,23 @@ export interface FilterMeta {
   readonly options?: readonly FilterOption[]
 }
 
+/**
+ * Discriminator-aware field-visibility predicate (issue #62). Set by
+ * `col(...).visibleWhen({ kind: 'esm_upload' })` on the server. The frontend
+ * evaluates this against the current form state on every change and shows or
+ * hides the field accordingly.
+ *
+ * Single value:    `{ kind: 'esm_upload' }`            (equality)
+ * Multi-value:     `{ kind: ['esm_upload', 'iframe'] }` (OR — value ∈ list)
+ * Multi-condition: `{ kind: 'iframe', requiresAuth: true }` (AND across keys)
+ *
+ * `required` and `visibleWhen` compose: a field that's both required and
+ * visibleWhen means "required when visible." Frontends should skip required
+ * validation while the field is hidden, and strip hidden fields from the
+ * submit payload so toggling the discriminator doesn't carry stale data.
+ */
+export type VisibleWhen = Readonly<Record<string, unknown | readonly unknown[]>>
+
 /** Reference from a field to its value-help endpoint — drives metadata-driven dropdowns. */
 export interface ValueHelpRef {
   /** Key under the BO's `valueHelps` map — the URL segment in `/bo/{name}/valueHelp/{key}`. */
@@ -50,6 +67,12 @@ export interface FieldMeta {
   readonly inForm: boolean
   readonly required: boolean
   readonly quick: boolean
+  /**
+   * Discriminator-aware visibility predicate (issue #62). When set, the
+   * frontend evaluates these key/value pairs against the current form state
+   * to decide whether to render the field. See `VisibleWhen` for semantics.
+   */
+  readonly visibleWhen?: VisibleWhen
 }
 
 // --- Aggregate metadata ---
@@ -119,6 +142,8 @@ export interface PublicFieldMeta {
   readonly inForm: boolean
   readonly required: boolean
   readonly quick: boolean
+  /** Discriminator-aware visibility predicate (issue #62). See `VisibleWhen`. */
+  readonly visibleWhen?: VisibleWhen
 }
 
 /** The shape returned by `GET /meta/{name}` — what frontends consume. */

--- a/packages/metadataui-spec/src/types.ts
+++ b/packages/metadataui-spec/src/types.ts
@@ -39,7 +39,11 @@ export interface FilterMeta {
  * validation while the field is hidden, and strip hidden fields from the
  * submit payload so toggling the discriminator doesn't carry stale data.
  */
-export type VisibleWhen = Readonly<Record<string, unknown | readonly unknown[]>>
+// Each entry is either a single scalar (string / number / boolean) the field's
+// own value must equal, or a `readonly` array of allowed scalars. Typed as
+// `unknown` because TS would collapse the union with `readonly unknown[]` to
+// `unknown` anyway — frontends should narrow at the call site.
+export type VisibleWhen = Readonly<Record<string, unknown>>
 
 /** Reference from a field to its value-help endpoint — drives metadata-driven dropdowns. */
 export interface ValueHelpRef {

--- a/packages/pgbo/src/metadata/index.ts
+++ b/packages/pgbo/src/metadata/index.ts
@@ -122,6 +122,9 @@ function buildFieldMeta(
     inForm: annotations.inForm ?? true,
     required: annotations.required ?? false,
     quick: annotations.quick ?? false,
+    // Issue #62 — surface the discriminator-aware visibility predicate so
+    // metadata-driven forms can hide irrelevant fields based on form state.
+    ...(annotations.visibleWhen && { visibleWhen: annotations.visibleWhen }),
   }
 }
 

--- a/packages/pgbo/src/schema/column.ts
+++ b/packages/pgbo/src/schema/column.ts
@@ -1,6 +1,6 @@
 // Column reference helper for view select — Phase 3
 
-import type { ColumnRef, FieldAnnotations, FieldKind, FilterOption, ViewDef, TableDef, AnyColumnBuilder } from './definitions.js'
+import type { ColumnRef, FieldAnnotations, FieldKind, FilterOption, ViewDef, TableDef, AnyColumnBuilder, VisibleWhen } from './definitions.js'
 import type { InferColumnType } from './infer.js'
 
 class ColumnRefImpl<T = unknown, R extends string = string> implements ColumnRef<T, R> {
@@ -41,6 +41,15 @@ class ColumnRefImpl<T = unknown, R extends string = string> implements ColumnRef
   filterOptions(opts: FilterOption[]): ColumnRef<T, R> { return this.withAnnotation({ filterOptions: opts }) }
   filterKey(k: string): ColumnRef<T, R> { return this.withAnnotation({ filterKey: k }) }
   quick(): ColumnRef<T, R> { return this.withAnnotation({ quick: true }) }
+  visibleWhen(predicate: VisibleWhen): ColumnRef<T, R> {
+    if (Object.keys(predicate).length === 0) {
+      throw new Error(
+        '.visibleWhen() requires at least one key/value pair. ' +
+        'Pass a non-empty object like { kind: \'esm_upload\' } or omit the call entirely.',
+      )
+    }
+    return this.withAnnotation({ visibleWhen: predicate })
+  }
 }
 
 /**

--- a/packages/pgbo/src/schema/definitions.ts
+++ b/packages/pgbo/src/schema/definitions.ts
@@ -143,8 +143,8 @@ export interface TableInput {
 
 // Re-export from @metadataui/spec so the field-kind contract has a single
 // source of truth across server (pgbo) and client (metadataui-client).
-import type { FieldKind, FilterOption } from '@metadataui/spec'
-export type { FieldKind, FilterOption }
+import type { FieldKind, FilterOption, VisibleWhen } from '@metadataui/spec'
+export type { FieldKind, FilterOption, VisibleWhen }
 
 export interface FieldAnnotations {
   readonly label?: string
@@ -161,6 +161,8 @@ export interface FieldAnnotations {
   readonly filterOptions?: readonly FilterOption[]
   readonly filterKey?: string
   readonly quick?: boolean
+  /** Discriminator-aware visibility predicate (issue #62). */
+  readonly visibleWhen?: VisibleWhen
 }
 
 // --- Column reference ---
@@ -191,6 +193,16 @@ export interface ColumnRef<T = unknown, R extends string = string> {
   filterOptions(opts: FilterOption[]): ColumnRef<T, R>
   filterKey(k: string): ColumnRef<T, R>
   quick(): ColumnRef<T, R>
+  /**
+   * Hide the field unless the form state matches the predicate (issue #62).
+   *
+   * - Single value:    `visibleWhen({ kind: 'esm_upload' })` (equality)
+   * - Multi-value:     `visibleWhen({ kind: ['esm_upload', 'iframe'] })` (OR)
+   * - Multi-condition: `visibleWhen({ kind: 'iframe', requiresAuth: true })` (AND)
+   *
+   * Combines with `.required()` — required only applies when the field is visible.
+   */
+  visibleWhen(predicate: VisibleWhen): ColumnRef<T, R>
 }
 
 // --- Subquery count reference ---

--- a/packages/pgbo/tests/schema/visible-when.test.ts
+++ b/packages/pgbo/tests/schema/visible-when.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { col } from '../../src/schema/column.js'
+import { table } from '../../src/schema/table.js'
+import { view } from '../../src/schema/view.js'
+import { text, integer } from '../../src/schema/types.js'
+import { viewMeta } from '../../src/metadata/index.js'
+
+const apps = table('app', {
+  columns: {
+    slug: text().notNull(),
+    kind: text().notNull(),
+    name: text().notNull(),
+    version: text(),
+    bundleRef: text(),
+    iframeUrl: text(),
+    requiresAuth: integer(),
+  },
+  primaryKey: ['slug'],
+})
+
+describe('.visibleWhen() column annotation (issue #62)', () => {
+  describe('column ref', () => {
+    it('stashes a single-value predicate on the annotation', () => {
+      const c = col('version').visibleWhen({ kind: 'esm_upload' })
+      expect(c.annotations.visibleWhen).toEqual({ kind: 'esm_upload' })
+    })
+
+    it('accepts multi-value predicates (OR semantics)', () => {
+      const c = col('version').visibleWhen({ kind: ['esm_upload', 'iframe'] })
+      expect(c.annotations.visibleWhen).toEqual({ kind: ['esm_upload', 'iframe'] })
+    })
+
+    it('accepts multi-condition predicates (AND across keys)', () => {
+      const c = col('version').visibleWhen({ kind: 'iframe', requiresAuth: true })
+      expect(c.annotations.visibleWhen).toEqual({ kind: 'iframe', requiresAuth: true })
+    })
+
+    it('throws on empty predicate', () => {
+      expect(() => col('version').visibleWhen({})).toThrow(/at least one key\/value pair/)
+    })
+
+    it('composes with other annotations', () => {
+      const c = col('version').required().visibleWhen({ kind: 'esm_upload' }).label('app.version')
+      expect(c.annotations.required).toBe(true)
+      expect(c.annotations.visibleWhen).toEqual({ kind: 'esm_upload' })
+      expect(c.annotations.label).toBe('app.version')
+    })
+  })
+
+  describe('metadata', () => {
+    const appView = view('app_view').from(apps).columns({
+      slug: col('slug').required().immutable(),
+      kind: col('kind').required(),
+      name: col('name').required(),
+      version: col('version').required().visibleWhen({ kind: 'esm_upload' }),
+      bundleRef: col('bundleRef').visibleWhen({ kind: 'esm_upload' }),
+      iframeUrl: col('iframeUrl').visibleWhen({ kind: 'iframe' }),
+    })
+
+    it('surfaces visibleWhen on FieldMeta', () => {
+      const meta = viewMeta(appView)
+      const version = meta.fields.find(f => f.key === 'version')!
+      expect(version.visibleWhen).toEqual({ kind: 'esm_upload' })
+
+      const iframe = meta.fields.find(f => f.key === 'iframeUrl')!
+      expect(iframe.visibleWhen).toEqual({ kind: 'iframe' })
+    })
+
+    it('omits visibleWhen on fields without the annotation', () => {
+      const meta = viewMeta(appView)
+      const slug = meta.fields.find(f => f.key === 'slug')!
+      expect(slug.visibleWhen).toBeUndefined()
+
+      const name = meta.fields.find(f => f.key === 'name')!
+      expect(name.visibleWhen).toBeUndefined()
+    })
+
+    it('preserves required + visibleWhen together (required-when-visible semantics)', () => {
+      const meta = viewMeta(appView)
+      const version = meta.fields.find(f => f.key === 'version')!
+      expect(version.required).toBe(true)
+      expect(version.visibleWhen).toEqual({ kind: 'esm_upload' })
+    })
+
+    it('multi-value predicate flows through unchanged', () => {
+      const v = view('multi_v').from(apps).columns({
+        version: col('version').visibleWhen({ kind: ['esm_upload', 'iframe'] }),
+      })
+      const meta = viewMeta(v)
+      expect(meta.fields[0]!.visibleWhen).toEqual({ kind: ['esm_upload', 'iframe'] })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Polymorphic tables have one discriminator column (\`kind\` / \`type\` / \`status\`) and other columns that only apply to specific values of it. Until now, \`/meta/{name}\` returned every field with \`inForm: true\` and no signal that some are conditional — every metadata-driven UI had to hard-code per-table dispatch logic.

This PR adds a column annotation that flows through to \`PublicFieldMeta\` so frontends hide irrelevant fields automatically.

## API

\`\`\`ts
const appView = view('app_view').from(apps).columns({
  slug:      col('slug').required().immutable(),
  kind:      col('kind').required(),                       // discriminator
  name:      col('name').required(),
  version:   col('version').required().visibleWhen({ kind: 'esm_upload' }),
  bundleRef: col('bundleRef').visibleWhen({ kind: 'esm_upload' }),
  iframeUrl: col('iframeUrl').visibleWhen({ kind: 'iframe' }),
})
\`\`\`

\`/meta/app\` returns \`version.visibleWhen = { kind: 'esm_upload' }\`. A metadata-driven form hides the field unless \`formState.kind === 'esm_upload'\`.

## Predicate shapes

| Shape | Semantics |
|---|---|
| \`{ kind: 'iframe' }\` | Equality |
| \`{ kind: ['iframe', 'esm_upload'] }\` | OR over the array |
| \`{ kind: 'iframe', requiresAuth: true }\` | AND across keys |

Empty predicates throw at definition time so accidentally-empty \`.visibleWhen({})\` fails fast.

## \`required\` composes

\`.required().visibleWhen({...})\` means *required when visible*. The frontend skips required validation while the field is hidden, and strips hidden fields from the submit payload so toggling the discriminator doesn't carry stale data.

## Where this lands

- **\`@metadataui/spec\`** gains \`VisibleWhen\` type + \`FieldMeta.visibleWhen\` + same on \`PublicFieldMeta\`.
- **\`@pgbo/core/schema\`** gains \`FieldAnnotations.visibleWhen\` + \`ColumnRef.visibleWhen(predicate)\` builder method.
- **\`buildFieldMeta\`** surfaces the annotation onto the emitted \`FieldMeta\`.
- **No server-side enforcement** — that's a v1.5 follow-up. Today the frontend is responsible for stripping hidden fields from submit payloads. Documented in \`docs/schema.md\`.

## Test plan

- [x] **Unit** (\`schema/visible-when.test.ts\`, 9 tests): predicate storage on the column ref (single/multi/AND); throws on empty; composes with \`required\`/\`label\`/\`immutable\`; \`viewMeta\` surfaces \`visibleWhen\` on annotated fields and omits it on un-annotated ones; multi-value predicates flow through unchanged.
- [x] All 528 tests pass (21 spec + 13 metadataui-client + **410 core** + 4 deprecation-shim + 80 fastify) — +9 from this PR.
- [x] \`npm run lint\` clean; \`npm run typecheck\` clean; \`npm run docs:build\` clean — \`schema.md\` gets a new "Discriminator-aware visibility" section.

## Backward compatibility

Purely additive — fields without \`.visibleWhen()\` keep \`visibleWhen: undefined\` and are always visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)