### PR TITLE
fix(fastify): pass systemManaged + visibleWhen through /meta (closes #68)

### DIFF
--- a/.changeset/public-meta-passthrough.md
+++ b/.changeset/public-meta-passthrough.md
@@ -1,0 +1,11 @@
+---
+"@pgbo/fastify": patch
+---
+
+Fix `/meta/{name}` dropping `systemManaged` and `visibleWhen` from the response (closes #68).
+
+`transformProjectionMeta` rebuilds each `PublicFieldMeta` as a strict object literal, and the field for `systemManaged` (issue #61) and `visibleWhen` (issue #62) was never copied through. Both are now spread conditionally so they surface on the wire when set, and stay absent when not — matching how `valueHelp` / `filterable` are already handled.
+
+This unblocks frontends that wanted to render `updatedAt` columns differently from regular fields, or hide fields based on a discriminator value (the headline use-case for `.visibleWhen()`).
+
+For composition with `.visibleWhen()` to flow end-to-end the BO's root must be the view that carries the annotated `col(...).visibleWhen(...)` reference (`defineBO(myView, ...)`). When the BO root is the underlying table, view-column annotations don't reach metadata — that's by design, the same constraint that already applies to `.searchable()` / `.label()`.

--- a/packages/pgbo-fastify/src/routes.ts
+++ b/packages/pgbo-fastify/src/routes.ts
@@ -100,6 +100,11 @@ function transformProjectionMeta(projection: ProjectionDef, meta: BOMeta): Publi
         inForm: f.hidden ? false : f.inForm,
         required: f.required,
         quick: f.quick,
+        // Surface system-managed timestamps (#61) and discriminator-aware
+        // visibility predicates (#62) on the wire — the conditional spread
+        // matches how `valueHelp` / `filterable` are handled (issue #68).
+        ...(f.systemManaged && { systemManaged: f.systemManaged }),
+        ...(f.visibleWhen && { visibleWhen: f.visibleWhen }),
       }
     })
   return { ...meta, name: projection.name, fields }

--- a/packages/pgbo-fastify/tests/meta-passthrough.test.ts
+++ b/packages/pgbo-fastify/tests/meta-passthrough.test.ts
@@ -1,0 +1,109 @@
+// Regression tests for issue #68 — `/meta/{name}` must surface
+// `systemManaged` (#61) and `visibleWhen` (#62) on each field.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import Fastify from 'fastify'
+import { table, view, text, timestamp, col, systemTimestamps } from '@pgbo/core/schema'
+import { defineBO, defineProjection } from '@pgbo/core/bo'
+import { createTestDatabase, type TestDatabase } from '@pgbo/core/testing'
+import { registerProjection } from '../src/index.js'
+
+const connectionString = process.env.PGBO_TEST_URL ?? 'postgresql://localhost:5432/postgres'
+
+const linkTable = table('link', {
+  columns: {
+    slug: text().notNull(),
+    kind: text().notNull(),
+    iframeUrl: text(),
+    label: text(),
+    ...systemTimestamps(),
+  },
+  primaryKey: ['slug'],
+})
+
+const linkView = view('link_view').from(linkTable).columns({
+  slug: col('slug'),
+  kind: col('kind'),
+  iframeUrl: col('iframeUrl').visibleWhen({ kind: 'iframe' }),
+  label: col('label'),
+  createdAt: col('createdAt'),
+  updatedAt: col('updatedAt'),
+})
+
+// BO root is the view so view-column annotations (`.visibleWhen()`) surface
+// in metadata. System-managed columns flow through either way because the
+// marker lives on the column builder itself.
+const linkBO = defineBO(linkView, {
+  paramField: 'slug',
+  actions: { create: {}, update: {}, delete: {} },
+})
+
+const linkProjection = defineProjection(linkBO, {
+  name: 'link',
+  actions: { read: true, create: true, update: true, delete: true },
+})
+
+describe('GET /meta/{name} — issue #68 passthrough', () => {
+  let testDb: TestDatabase
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase({
+      connectionString,
+      schema: [linkTable],
+      seed: [
+        `CREATE OR REPLACE VIEW link_view AS
+         SELECT slug, kind, iframe_url, label, created_at, updated_at FROM link`,
+      ],
+    })
+  })
+
+  afterAll(async () => {
+    await testDb.dispose()
+  })
+
+  function makeApp() {
+    const app = Fastify()
+    registerProjection(app, testDb.db, {
+      projection: linkProjection,
+      view: linkView,
+      extractContext: () => ({ app, db: testDb.db, locale: 'en' }),
+    })
+    return app
+  }
+
+  it('passes visibleWhen through to PublicFieldMeta', async () => {
+    const app = makeApp()
+    const res = await app.inject({ method: 'GET', url: '/meta/link' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    const iframeUrl = body.fields.find((f: { key: string }) => f.key === 'iframeUrl')
+    expect(iframeUrl).toBeDefined()
+    expect(iframeUrl.visibleWhen).toEqual({ kind: 'iframe' })
+    await app.close()
+  })
+
+  it('passes systemManaged through to PublicFieldMeta', async () => {
+    const app = makeApp()
+    const res = await app.inject({ method: 'GET', url: '/meta/link' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    const createdAt = body.fields.find((f: { key: string }) => f.key === 'createdAt')
+    const updatedAt = body.fields.find((f: { key: string }) => f.key === 'updatedAt')
+    expect(createdAt.systemManaged).toBe('createdAt')
+    expect(updatedAt.systemManaged).toBe('updatedAt')
+    await app.close()
+  })
+
+  it('omits visibleWhen / systemManaged keys when not annotated', async () => {
+    const app = makeApp()
+    const res = await app.inject({ method: 'GET', url: '/meta/link' })
+    const body = res.json()
+    const slug = body.fields.find((f: { key: string }) => f.key === 'slug')
+    const label = body.fields.find((f: { key: string }) => f.key === 'label')
+    expect('visibleWhen' in slug).toBe(false)
+    expect('systemManaged' in slug).toBe(false)
+    expect('visibleWhen' in label).toBe(false)
+    expect('systemManaged' in label).toBe(false)
+    await app.close()
+  })
+})


### PR DESCRIPTION
## Summary

\`transformProjectionMeta\` rebuilds each \`PublicFieldMeta\` from a strict object literal that didn't copy through the two fields added in 1.2.0 / 3.2.0:

- \`systemManaged\` (issue #61)
- \`visibleWhen\` (issue #62)

Both are now spread conditionally so they surface on the wire when set, and stay absent when not — matching how \`valueHelp\` / \`filterable\` are already handled.

## Why it matters

- **#62 was completely non-functional** before this — the predicate never reached the frontend, so discriminator-aware visibility couldn't work end-to-end.
- **#61 partly worked** because \`inForm: false\` + \`immutable: true\` flowed through and were enough to skip the field in forms, but the explicit \`'createdAt' | 'updatedAt'\` tag was invisible to clients that wanted to style audit timestamps differently.

## Important note for \`.visibleWhen()\` users

For the predicate to flow end-to-end the BO's root must be the view that carries the annotated column refs:

\`\`\`ts
const myBO = defineBO(myView, { ... })   // ✓ visibleWhen surfaces
const myBO = defineBO(myTable, { ... })  // ✗ view-column annotations don't reach meta
\`\`\`

Same constraint already applies to \`.searchable()\` and \`.label()\`. The regression test demonstrates the working setup.

## Test plan

- [x] New \`tests/meta-passthrough.test.ts\` — 3 cases:
  - \`visibleWhen\` flows through to \`PublicFieldMeta\`
  - \`systemManaged\` flows through (both \`createdAt\` and \`updatedAt\`)
  - Both keys are absent when not annotated
- [x] Full suite green — 584 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)